### PR TITLE
<FEATURE>(Divider) 实现divider组件、为一些控件实现一些方法

### DIFF
--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -127,7 +127,7 @@ namespace Element
     }
 
     // Dialog::Accepted / Dialog::Rejected / Dialog::Closed
-    int Dialog::show()
+    void Dialog::show()
     {
         QDialog::show();
         activateWindow();
@@ -142,9 +142,8 @@ namespace Element
             connect(this, &QDialog::finished, &loop, &QEventLoop::quit);
             loop.exec();
 
-            return result();
+            return;
         }
-        return QDialog::Rejected;
     }
 
     void Dialog::closeDialog(int result, bool emitClosed)

--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -1,7 +1,11 @@
 #include "dialog.h"
+#include "shadow.h"
+#include "mask.h"
 
 #include <QBoxLayout>
-
+#include <QTimer>
+#include <QGraphicsDropShadowEffect>
+#include <QEventLoop>
 
 namespace Element
 {
@@ -16,35 +20,86 @@ namespace Element
         , _cancel(new Button("Cancel", this))
         , _confirm(new Button("Confirm", this))
     {
-        setWindowFlags(windowFlags()
-                       & ~Qt::WindowContextHelpButtonHint
-                       & ~Qt::WindowCloseButtonHint);
-        setWindowTitle("Dialog");
-        setFixedSize(500, 175);
+        setAttribute(Qt::WA_DeleteOnClose);
+        setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+        setAttribute(Qt::WA_TranslucentBackground);
+        setFixedSize(500, 202);
         setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        setStyleSheet("background-color: white;");
 
-        _title->setSize(Text::Size::Large);
-        _confirm->setType(Button::Type::Primary);
+        QWidget* outerFrame = new QWidget(this);
+        outerFrame->setGeometry(rect());
+        QGraphicsDropShadowEffect* shadowEffect = new QGraphicsDropShadowEffect(outerFrame);
+        shadowEffect->setBlurRadius(12);
+        shadowEffect->setColor(QColor(0, 0, 0, 102));
+        shadowEffect->setOffset(0, 2);
+        outerFrame->setGraphicsEffect(shadowEffect);
 
-        QVBoxLayout *mainLayout = new QVBoxLayout(this);
+        QWidget* contentFrame = new QWidget(outerFrame);
+        contentFrame->setStyleSheet("background-color: white; border-radius: 4px; border: none;");
+        contentFrame->setGeometry(outerFrame->rect());
+
+        _title->setParent(contentFrame);
+        _content->setParent(contentFrame);
+        _cancel->setParent(contentFrame);
+        _confirm->setParent(contentFrame);
+        _close = new QLabel(contentFrame);
+        _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 20));
+        _close->setAttribute(Qt::WA_Hover);
+        _close->installEventFilter(this);
+
+        QHBoxLayout* headerLayout = new QHBoxLayout();
+        headerLayout->addWidget(_title);
+        headerLayout->addStretch();
+        headerLayout->addWidget(_close);
+
+        QVBoxLayout* mainLayout = new QVBoxLayout(contentFrame);
         mainLayout->setContentsMargins(20, 20, 20, 20);
         mainLayout->setSpacing(20);
 
-        QHBoxLayout *buttonLayout = new QHBoxLayout();
+        QHBoxLayout* buttonLayout = new QHBoxLayout();
         buttonLayout->setSpacing(10);
         buttonLayout->addStretch();
         buttonLayout->addWidget(_cancel);
         buttonLayout->addWidget(_confirm);
 
-        mainLayout->addWidget(_title);
+        mainLayout->addLayout(headerLayout);
         mainLayout->addWidget(_content);
         mainLayout->addLayout(buttonLayout);
 
-        setLayout(mainLayout);
+        contentFrame->setLayout(mainLayout);
 
-        connect(_cancel, &QPushButton::clicked, this, &QDialog::reject);
-        connect(_confirm, &QPushButton::clicked, this, &QDialog::accept);
+        QVBoxLayout* outerLayout = new QVBoxLayout(outerFrame);
+        outerLayout->setContentsMargins(12, 12, 12, 12);
+        outerLayout->addWidget(contentFrame);
+
+        QVBoxLayout* windowLayout = new QVBoxLayout(this);
+        windowLayout->setContentsMargins(0, 0, 0, 0);
+        windowLayout->addWidget(outerFrame);
+        setLayout(windowLayout);
+
+        _title->setSize(Text::Size::Large);
+        _confirm->setType(Button::Type::Primary);
+
+        connect(_cancel, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Rejected, false); });
+        connect(_confirm, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Accepted, false); });
+
+        setWindowOpacity(0.0);
+
+        _moveAni = new QPropertyAnimation(this, "geometry");
+        _moveAni->setDuration(300);
+        _moveAni->setEasingCurve(QEasingCurve::OutCubic);
+
+        _opaAni = new QPropertyAnimation(this, "windowOpacity");
+        _opaAni->setDuration(300);
+        _opaAni->setStartValue(0.0);
+        _opaAni->setEndValue(1.0);
+        _opaAni->setEasingCurve(QEasingCurve::OutCubic);
+
+        _inAni = new QParallelAnimationGroup(this);
+        _inAni->addAnimation(_moveAni);
+        _inAni->addAnimation(_opaAni);
+
+        _outAni = new QParallelAnimationGroup(this);
     }
 
     Dialog& Dialog::setTitle(const QString &title)
@@ -59,10 +114,51 @@ namespace Element
         return *this;
     }
 
-    // Dialog::Accepted / Dialog::Rejected
+    Dialog& Dialog::setModal(bool modal)
+    {
+        _modal = modal;
+        return *this;
+    }
+
+    Dialog& Dialog::setBeforeClose(const std::function<void(std::function<void()>)>& callback)
+    {
+        _beforeCloseCallback = callback;
+        return *this;
+    }
+
+    // Dialog::Accepted / Dialog::Rejected / Dialog::Closed
     int Dialog::show()
     {
-        return exec();
+        QDialog::show();
+        activateWindow();
+        setFocus();
+
+        QWidget* pw = qobject_cast<QWidget*>(parent());
+        if (pw && _modal) {
+            Mask* mask = MaskEf::setMask(this, pw);
+            connect(mask, &Mask::clicked, this, [this]() { closeDialog(QDialog::Rejected, true); });
+
+            QEventLoop loop;
+            connect(this, &QDialog::finished, &loop, &QEventLoop::quit);
+            loop.exec();
+
+            return result();
+        }
+        return QDialog::Rejected;
+    }
+
+    void Dialog::closeDialog(int result, bool emitClosed)
+    {
+        if (_beforeCloseCallback && emitClosed)
+        {
+            _beforeCloseCallback([this, result, emitClosed]() {
+                doClose(result, emitClosed);
+            });
+        }
+        else
+        {
+            doClose(result, emitClosed);
+        }
     }
 
     void Dialog::showEvent(QShowEvent *event)
@@ -77,5 +173,85 @@ namespace Element
             move(parentWidget()->pos().x() + (parentWidget()->width() - width()) / 2,
                  targetY);
         }
+
+        QRect endRect = geometry();
+        QRect startRect = endRect;
+        startRect.moveTop(endRect.y() - 20);
+        _moveAni->setStartValue(startRect);
+        _moveAni->setEndValue(endRect);
+
+        _opaAni->setStartValue(0.0);
+        _opaAni->setEndValue(1.0);
+
+        _inAni->start();
+    }
+
+    void Dialog::keyPressEvent(QKeyEvent *event)
+    {
+        if (event->key() == Qt::Key_Escape)
+            closeDialog(QDialog::Rejected, true);
+        else
+            QDialog::keyPressEvent(event);
+    }
+
+    bool Dialog::eventFilter(QObject* watched, QEvent* event)
+    {
+        if (watched == _close)
+        {
+            if (event->type() == QEvent::HoverEnter)
+            {
+                _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::primary(), 20));
+                _close->setCursor(Qt::PointingHandCursor);
+                return true;
+            }
+            else if (event->type() == QEvent::HoverLeave)
+            {
+                _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 20));
+                _close->setCursor(Qt::ArrowCursor);
+                return true;
+            }
+            else if (event->type() == QEvent::MouseButtonPress)
+            {
+                closeDialog(QDialog::Rejected, true);
+            }
+        }
+        return QWidget::eventFilter(watched, event);
+    }
+
+    void Dialog::doClose(int result, bool emitClosed)
+    {
+        if (_outAni->state() == QAbstractAnimation::Running)
+            return;
+
+        setResult(result);
+
+        _cancel->setDisabled(true);
+        _confirm->setDisabled(true);
+
+        _opaAni->setStartValue(windowOpacity());
+        _opaAni->setEndValue(0.0);
+        _opaAni->setDuration(150);
+        _opaAni->setEasingCurve(QEasingCurve::OutCubic);
+        _outAni->clear();
+        _outAni->addAnimation(_opaAni);
+
+        QRect endRect = geometry();
+        endRect.moveTop(endRect.y() - 20);
+        _moveAni->setStartValue(geometry());
+        _moveAni->setEndValue(endRect);
+        _moveAni->setDuration(150);
+        _moveAni->setEasingCurve(QEasingCurve::OutCubic);
+        _outAni->addAnimation(_moveAni);
+
+        connect(_outAni, &QParallelAnimationGroup::finished, this, [this, result, emitClosed]() {
+            if (result == QDialog::Accepted)
+                emit accepted();
+            else if (emitClosed)
+                emit closed();
+            else
+                emit rejected();
+            QDialog::close();
+        });
+        _outAni->start();
     }
 }

--- a/components/dialog.h
+++ b/components/dialog.h
@@ -4,6 +4,8 @@
 #include "button.h"
 
 #include <QDialog>
+#include <QPropertyAnimation>
+#include <QParallelAnimationGroup>
 
 namespace Element
 {
@@ -11,10 +13,19 @@ namespace Element
     {
     Q_OBJECT
 
+    signals:
+        void accepted();
+        void rejected();
+        void closed();  // Click ESC, mask or close button.
+
     public:
         Dialog& setTitle(const QString& title);
         Dialog& setContent(const QString& content);
+        Dialog& setModal(bool modal);
+        Dialog& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
+
         int show();
+        void closeDialog(int result, bool emitClosed);
 
     public:
         Dialog(QWidget* parent = nullptr);
@@ -22,11 +33,25 @@ namespace Element
 
     protected:
         void showEvent(QShowEvent *event) override;
+        void keyPressEvent(QKeyEvent *event) override;
+        bool eventFilter(QObject* watched, QEvent* event) override;
 
     private:
+        void doClose(int result, bool emitClosed);
+
+    private:
+        bool _modal = true;
         Text* _title;
         Text* _content;
         Button* _cancel;
         Button* _confirm;
+        std::function<void(std::function<void()>)> _beforeCloseCallback;
+
+    private:
+        QLabel* _close;
+        QPropertyAnimation* _opaAni;
+        QPropertyAnimation* _moveAni;
+        QParallelAnimationGroup* _inAni;
+        QParallelAnimationGroup* _outAni;
     };
 }

--- a/components/dialog.h
+++ b/components/dialog.h
@@ -24,7 +24,7 @@ namespace Element
         Dialog& setModal(bool modal);
         Dialog& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
 
-        int show();
+        void show();
         void closeDialog(int result, bool emitClosed);
 
     public:

--- a/components/divider.cpp
+++ b/components/divider.cpp
@@ -2,5 +2,327 @@
 
 namespace Element
 {
+    class HLine : public QWidget
+    {
+    public:
+        explicit HLine(QWidget* parent = nullptr) : QWidget(parent)
+        {
+            setFixedHeight(1);
+            setMinimumWidth(20);
+            setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+            setProperty("color", "#dcdfe6");
+            setProperty("style", "solid");
+        }
 
+        void setLineColor(const QString& color)
+        {
+            if (color != property("color").toString())
+            {
+                setProperty("color", color);
+                update();
+            }
+        }
+
+        void setLineStyle(Divider::LineStyle ls)
+        {
+            QString style = Divider::getLineStyleString(ls);
+            if (style != property("style").toString())
+            {
+                setProperty("style", style);
+                update();
+            }
+        }
+
+    protected:
+        void paintEvent(QPaintEvent*) override
+        {
+            QPainter painter(this);
+            painter.setRenderHint(QPainter::Antialiasing, false);
+
+            QString color = property("color").toString();
+            QString style = property("style").toString();
+
+            QPen pen;
+            pen.setColor(QColor(color));
+            pen.setWidth(1);
+            if (style == "solid")
+                pen.setStyle(Qt::SolidLine);
+            else if (style == "dashed")
+                pen.setStyle(Qt::DashLine);
+            else if (style == "dotted")
+                pen.setStyle(Qt::DotLine);
+            else if(style == "dashDotLine")
+                pen.setStyle(Qt::DashDotLine);
+            else if(style == "dashDotDotLine")
+                pen.setStyle(Qt::DashDotDotLine);
+            painter.setPen(pen);
+            painter.drawLine(0, 0, width(), 0);
+        }
+    };
+
+    QString Divider::getLineStyleString(LineStyle style)
+    {
+        switch (style)
+        {
+        case LineStyle::Solid:      return "solid";
+        case LineStyle::Dashed:     return "dashed";
+        case LineStyle::Dotted:     return "dotted";
+        case LineStyle::DashDotLine:  return "dashDotLine";
+        case LineStyle::DashDotDotLine:  return "dashDotDotLine";
+        default:                    return "solid";
+        }
+    }
+
+    HDivider::HDivider(QWidget* parent)
+        : Divider(parent)
+    {
+        init();
+        adjust(ContentPosition::Empty);
+    }
+
+    HDivider::HDivider(const QString& text, HDivider::ContentPosition conPos, QWidget* parent)
+        : Divider(parent)
+    {
+        init();
+        if(conPos == ContentPosition::Empty) return;
+
+        QLabel* txt = new QLabel(this);
+        txt->setText(text);
+        txt->setAlignment(Qt::AlignCenter);
+        QFont font = FontHelper().getFont();
+        font.setPointSize(10);
+        txt->setFont(font);
+        setContent(txt);
+        adjust(conPos);
+    }
+
+    HDivider::HDivider(QWidget* content, ContentPosition conPos, QWidget* parent)
+        : Divider(parent)
+    {
+        init();
+        setContent(content);
+        adjust(conPos);
+    }
+
+    HDivider::HDivider(const QPixmap& pm, ContentPosition conPos, QWidget* parent)
+        : Divider(parent)
+    {
+        init();
+        QLabel* l = new QLabel(_content);
+        l->setPixmap(pm);
+        setContent(l);
+        adjust(conPos);
+    }
+
+    void HDivider::init()
+    {
+        QHBoxLayout* layout= new QHBoxLayout(this);
+        layout->setContentsMargins(0, 0, 0, 0);
+        _leftLine = new HLine();
+        layout->addWidget(_leftLine);
+
+        _content = new QWidget(this);
+        QHBoxLayout* l = new QHBoxLayout(_content);
+        l->setContentsMargins(0, 0, 0, 0);
+        layout->addWidget(_content);
+
+        _rightLine = new HLine();
+        layout->addWidget(_rightLine);
+        layout->setSpacing(20);
+    }
+
+    HDivider& HDivider::setSpacing(int spacing)
+    {
+        this->layout()->setSpacing(spacing);
+        return *this;
+    }
+
+    HDivider& HDivider::setPixmap(const QPixmap& pm)
+    {
+        QLabel* l = new QLabel(_content);
+        l->setPixmap(pm);
+        setContent(l);
+        return *this;
+    }
+
+    HDivider& HDivider::setText(const QString text)
+    {
+        QLabel* txt = new QLabel(this);
+        txt->setText(text);
+        txt->setAlignment(Qt::AlignCenter);
+        QFont font = FontHelper().getFont();
+        font.setPointSize(10);
+        txt->setFont(font);
+        setContent(txt);
+
+        if(_conPos == ContentPosition::Empty)
+            adjust(ContentPosition::Center);
+
+        return *this;
+    }
+
+    HDivider& HDivider::setContent(QWidget* content)
+    {
+        if(content)
+        {
+            QLayout* layout = _content->layout();
+            QWidget* widget = nullptr;
+
+            if (layout->count() > 0)
+            {
+                QLayoutItem* item = layout->itemAt(0);
+                if (item) widget = item->widget();
+            }
+
+            if (widget == content) return *this;
+
+            while (layout->count() > 0)
+            {
+                QLayoutItem* item = layout->takeAt(0);
+                if (QWidget* w = item->widget())
+                    w->deleteLater();
+
+                delete item;
+            }
+
+            layout->addWidget(content);
+            _content->setVisible(true);
+        }
+        else
+        {
+            _content->setVisible(false);
+            _rightLine->setVisible(false);
+        }
+
+        return *this;
+    }
+
+    HDivider& HDivider::setContentPosition(HDivider::ContentPosition conPos)
+    {
+        adjust(conPos);
+        return *this;
+    }
+
+    void HDivider::adjust(ContentPosition conPos)
+    {
+        if(_content->layout()->count()>0 && (conPos != ContentPosition::Empty))
+        {
+            _content->setVisible(true);
+            _rightLine->setVisible(true);
+
+            int streFactor1 = 0, streFactor2 = 0, streFactor3 = 0;
+            switch (conPos)
+            {
+            case ContentPosition::Center:
+                streFactor1 = streFactor3 = 1;
+                streFactor2 = 0;
+                break;
+            case ContentPosition::Left:
+                streFactor1 = streFactor2 = 0;
+                streFactor3 = 1;
+                break;
+            case ContentPosition::Right:
+                streFactor2 = streFactor3 = 0;
+                streFactor1 = 1;
+                break;
+            case ContentPosition::Empty:
+                break;
+            }
+
+            QBoxLayout* layout = qobject_cast<QBoxLayout*>(this->layout());
+            layout->setStretchFactor(_leftLine, streFactor1);
+            layout->setStretchFactor(_content, streFactor2);
+            layout->setStretchFactor(_rightLine, streFactor3);
+            _conPos = conPos;
+        }
+        else
+        {
+            _content->setVisible(false);
+            _rightLine->setVisible(false);
+        }
+    }
+
+    HDivider& HDivider::setLineColor(const QString& color)
+    {
+        _leftLine->setLineColor(color);
+        _rightLine->setLineColor(color);
+        return *this;
+    }
+
+    HDivider& HDivider::setLineStyle(Divider::LineStyle ls)
+    {
+        _leftLine->setLineStyle(ls);
+        _rightLine->setLineStyle(ls);
+        return *this;
+    }
+
+    HDivider::ContentPosition HDivider::getContentPosition()
+    {
+        return _conPos;
+    }
+
+    Divider::Direction HDivider::getDirection() const
+    {
+        return Direction::Horizontal;
+    }
+
+    VDivider::VDivider(QWidget* parent)
+        : Divider(parent)
+    {
+        setFixedWidth(1);
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+        setProperty("color", "#dcdfe6");
+        setProperty("style", "solid");
+    }
+
+    Divider::Direction VDivider::getDirection() const
+    {
+        return Direction::Vertical;
+    }
+
+    VDivider& VDivider::setLineColor(const QString& color)
+    {
+        if (color != property("color").toString())
+        {
+            setProperty("color", color);
+            update();
+        }
+        return *this;
+    }
+
+    VDivider& VDivider::setLineStyle(Divider::LineStyle ls)
+    {
+        QString style = Divider::getLineStyleString(ls);
+        if (style != property("style").toString())
+        {
+            setProperty("style", style);
+            update();
+        }
+        return *this;
+    }
+
+    void VDivider::paintEvent(QPaintEvent*)
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, false);
+
+        QString color = property("color").toString();
+        QString style = property("style").toString();
+
+        QPen pen;
+        pen.setColor(QColor(color));
+        pen.setWidth(1);
+        if (style == "solid")
+            pen.setStyle(Qt::SolidLine);
+        else if (style == "dashed")
+            pen.setStyle(Qt::DashLine);
+        else if (style == "dotted")
+            pen.setStyle(Qt::DotLine);
+        else if(style == "dashDotLine")
+            pen.setStyle(Qt::DashDotLine);
+        else if(style == "dashDotDotLine")
+            pen.setStyle(Qt::DashDotDotLine);
+        painter.setPen(pen);
+        painter.drawLine(0, 0, 0, height());
+    }
 }

--- a/components/divider.cpp
+++ b/components/divider.cpp
@@ -1,4 +1,5 @@
 #include "divider.h"
+#include "text.h"
 
 namespace Element
 {
@@ -54,23 +55,6 @@ namespace Element
         l->setPixmap(pm);
         setContent(l);
         adjust(conPos);
-    }
-
-    void HDivider::init()
-    {
-        QHBoxLayout* layout= new QHBoxLayout(this);
-        layout->setContentsMargins(0, 0, 0, 0);
-        _leftLine = new HLine();
-        layout->addWidget(_leftLine);
-
-        _content = new QWidget(this);
-        QHBoxLayout* l = new QHBoxLayout(_content);
-        l->setContentsMargins(0, 0, 0, 0);
-        layout->addWidget(_content);
-
-        _rightLine = new HLine();
-        layout->addWidget(_rightLine);
-        layout->setSpacing(20);
     }
 
     HDivider& HDivider::setSpacing(int spacing)
@@ -145,6 +129,37 @@ namespace Element
         return *this;
     }
 
+    HDivider& HDivider::setLineColor(const QString& color)
+    {
+        _leftLine->setLineColor(color);
+        _rightLine->setLineColor(color);
+        return *this;
+    }
+
+    HDivider& HDivider::setLineStyle(Divider::LineStyle ls)
+    {
+        _leftLine->setLineStyle(ls);
+        _rightLine->setLineStyle(ls);
+        return *this;
+    }
+
+    void HDivider::init()
+    {
+        QHBoxLayout* layout= new QHBoxLayout(this);
+        layout->setContentsMargins(0, 0, 0, 0);
+        _leftLine = new HLine();
+        layout->addWidget(_leftLine);
+
+        _content = new QWidget(this);
+        QHBoxLayout* l = new QHBoxLayout(_content);
+        l->setContentsMargins(0, 0, 0, 0);
+        layout->addWidget(_content);
+
+        _rightLine = new HLine();
+        layout->addWidget(_rightLine);
+        layout->setSpacing(20);
+    }
+
     void HDivider::adjust(ContentPosition conPos)
     {
         if(_content->layout()->count()>0 && (conPos != ContentPosition::Empty))
@@ -182,20 +197,6 @@ namespace Element
             _content->setVisible(false);
             _rightLine->setVisible(false);
         }
-    }
-
-    HDivider& HDivider::setLineColor(const QString& color)
-    {
-        _leftLine->setLineColor(color);
-        _rightLine->setLineColor(color);
-        return *this;
-    }
-
-    HDivider& HDivider::setLineStyle(Divider::LineStyle ls)
-    {
-        _leftLine->setLineStyle(ls);
-        _rightLine->setLineStyle(ls);
-        return *this;
     }
 
     HDivider::ContentPosition HDivider::getContentPosition()

--- a/components/divider.cpp
+++ b/components/divider.cpp
@@ -2,64 +2,6 @@
 
 namespace Element
 {
-    class HLine : public QWidget
-    {
-    public:
-        explicit HLine(QWidget* parent = nullptr) : QWidget(parent)
-        {
-            setFixedHeight(1);
-            setMinimumWidth(20);
-            setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-            setProperty("color", "#dcdfe6");
-            setProperty("style", "solid");
-        }
-
-        void setLineColor(const QString& color)
-        {
-            if (color != property("color").toString())
-            {
-                setProperty("color", color);
-                update();
-            }
-        }
-
-        void setLineStyle(Divider::LineStyle ls)
-        {
-            QString style = Divider::getLineStyleString(ls);
-            if (style != property("style").toString())
-            {
-                setProperty("style", style);
-                update();
-            }
-        }
-
-    protected:
-        void paintEvent(QPaintEvent*) override
-        {
-            QPainter painter(this);
-            painter.setRenderHint(QPainter::Antialiasing, false);
-
-            QString color = property("color").toString();
-            QString style = property("style").toString();
-
-            QPen pen;
-            pen.setColor(QColor(color));
-            pen.setWidth(1);
-            if (style == "solid")
-                pen.setStyle(Qt::SolidLine);
-            else if (style == "dashed")
-                pen.setStyle(Qt::DashLine);
-            else if (style == "dotted")
-                pen.setStyle(Qt::DotLine);
-            else if(style == "dashDotLine")
-                pen.setStyle(Qt::DashDotLine);
-            else if(style == "dashDotDotLine")
-                pen.setStyle(Qt::DashDotDotLine);
-            painter.setPen(pen);
-            painter.drawLine(0, 0, width(), 0);
-        }
-    };
-
     QString Divider::getLineStyleString(LineStyle style)
     {
         switch (style)
@@ -324,5 +266,61 @@ namespace Element
             pen.setStyle(Qt::DashDotDotLine);
         painter.setPen(pen);
         painter.drawLine(0, 0, 0, height());
+    }
+
+    HLine::HLine(QWidget* parent)
+        : QWidget(parent)
+    {
+        setFixedHeight(1);
+        setMinimumWidth(20);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        setProperty("color", "#dcdfe6");
+        setProperty("style", "solid");
+    }
+
+    HLine& HLine::setLineColor(const QString& color)
+    {
+        if (color != property("color").toString())
+        {
+            setProperty("color", color);
+            update();
+        }
+        return *this;
+    }
+
+    HLine& HLine::setLineStyle(Divider::LineStyle ls)
+    {
+        QString style = Divider::getLineStyleString(ls);
+        if (style != property("style").toString())
+        {
+            setProperty("style", style);
+            update();
+        }
+        return *this;
+    }
+
+    void HLine::paintEvent(QPaintEvent*)
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, false);
+
+        QString color = property("color").toString();
+        QString style = property("style").toString();
+
+        QPen pen;
+        pen.setColor(QColor(color));
+        pen.setWidth(1);
+        if (style == "solid")
+            pen.setStyle(Qt::SolidLine);
+        else if (style == "dashed")
+            pen.setStyle(Qt::DashLine);
+        else if (style == "dotted")
+            pen.setStyle(Qt::DotLine);
+        else if(style == "dashDotLine")
+            pen.setStyle(Qt::DashDotLine);
+        else if(style == "dashDotDotLine")
+            pen.setStyle(Qt::DashDotDotLine);
+        painter.setPen(pen);
+        painter.drawLine(0, 0, width(), 0);
     }
 }

--- a/components/divider.h
+++ b/components/divider.h
@@ -1,18 +1,99 @@
 #pragma once
 
 #include <QWidget>
+#include <QBoxLayout>
+#include <QPaintEvent>
+
+#include "text.h"
 
 namespace Element
 {
-
     class Divider : public QWidget
     {
     Q_OBJECT
     public:
+        enum class Direction
+        {
+            Horizontal,
+            Vertical
+        };
+
+        enum class LineStyle
+        {
+            Solid,
+            Dashed,
+            Dotted,
+            DashDotLine,
+            DashDotDotLine
+        };
+
     public:
-    public:
-    private:
-    private:
+        virtual Direction getDirection() const = 0;
+        static QString getLineStyleString(LineStyle style);
+
+    protected:
+        explicit Divider(QWidget* parent = nullptr) : QWidget(parent) {}
     };
 
+    class HLine;
+
+    class HDivider : public Divider
+    {
+    Q_OBJECT
+    public:
+        enum class ContentPosition
+        {
+            Empty,
+            Center,
+            Left,
+            Right,
+        };
+
+    public:
+        HDivider(QWidget* parent = nullptr);
+        HDivider(const QString& text, ContentPosition conPos = ContentPosition::Center, QWidget* parent = nullptr);
+        HDivider(const QPixmap& pm, ContentPosition conPos = ContentPosition::Center, QWidget* parent = nullptr);
+        HDivider(QWidget* content, ContentPosition conPos, QWidget* parent = nullptr);
+
+    public:
+        Direction getDirection() const override;
+        ContentPosition getContentPosition();
+
+    public:
+        HDivider& setText(const QString text);
+        HDivider& setContent(QWidget* content);
+        HDivider& setContentPosition(HDivider::ContentPosition conPos);
+        HDivider& setPixmap(const QPixmap& pm);
+        HDivider& setLineColor(const QString& color);
+        HDivider& setLineStyle(Divider::LineStyle ls);
+        HDivider& setSpacing(int spacing);
+
+    private:
+        void init();
+        void adjust(ContentPosition conPos);
+
+    private:
+        ContentPosition _conPos = ContentPosition::Empty;
+
+    protected:
+        QWidget* _content = nullptr;
+        HLine* _leftLine;
+        HLine* _rightLine;
+
+    };
+
+    class VDivider : public Divider
+    {
+        Q_OBJECT
+    public:
+        explicit VDivider(QWidget* parent = nullptr);
+        Direction getDirection() const override;
+
+    public:
+        VDivider& setLineColor(const QString& color);
+        VDivider& setLineStyle(Divider::LineStyle ls);
+
+    protected:
+        void paintEvent(QPaintEvent* event) override;
+    };
 }

--- a/components/divider.h
+++ b/components/divider.h
@@ -8,6 +8,8 @@
 
 namespace Element
 {
+    class HLine;
+
     class Divider : public QWidget
     {
     Q_OBJECT
@@ -34,8 +36,6 @@ namespace Element
     protected:
         explicit Divider(QWidget* parent = nullptr) : QWidget(parent) {}
     };
-
-    class HLine;
 
     class HDivider : public Divider
     {
@@ -95,5 +95,18 @@ namespace Element
 
     protected:
         void paintEvent(QPaintEvent* event) override;
+    };
+
+    class HLine : public QWidget
+    {
+    public:
+        explicit HLine(QWidget* parent = nullptr);
+
+    public:
+        HLine& setLineColor(const QString& color);
+        HLine& setLineStyle(Divider::LineStyle ls);
+
+    protected:
+        void paintEvent(QPaintEvent*) override;
     };
 }

--- a/components/divider.h
+++ b/components/divider.h
@@ -4,8 +4,6 @@
 #include <QBoxLayout>
 #include <QPaintEvent>
 
-#include "text.h"
-
 namespace Element
 {
     class HLine;
@@ -28,6 +26,10 @@ namespace Element
             DashDotLine,
             DashDotDotLine
         };
+
+    public:
+        virtual Divider& setLineColor(const QString& color) = 0;
+        virtual Divider& setLineStyle(LineStyle ls) = 0;
 
     public:
         virtual Direction getDirection() const = 0;
@@ -64,8 +66,8 @@ namespace Element
         HDivider& setContent(QWidget* content);
         HDivider& setContentPosition(HDivider::ContentPosition conPos);
         HDivider& setPixmap(const QPixmap& pm);
-        HDivider& setLineColor(const QString& color);
-        HDivider& setLineStyle(Divider::LineStyle ls);
+        HDivider& setLineColor(const QString& color) override;
+        HDivider& setLineStyle(Divider::LineStyle ls) override;
         HDivider& setSpacing(int spacing);
 
     private:
@@ -90,8 +92,8 @@ namespace Element
         Direction getDirection() const override;
 
     public:
-        VDivider& setLineColor(const QString& color);
-        VDivider& setLineStyle(Divider::LineStyle ls);
+        VDivider& setLineColor(const QString& color) override;
+        VDivider& setLineStyle(Divider::LineStyle ls) override;
 
     protected:
         void paintEvent(QPaintEvent* event) override;

--- a/components/message.cpp
+++ b/components/message.cpp
@@ -32,8 +32,8 @@ namespace Element
         //setAttribute(Qt::WA_DeleteOnClose);
 
         _text->setFont(FontHelper(_text->font())
-                .setPointSize(Comm::defaultFontSize)
-                .getFont());
+                           .setPointSize(Comm::defaultFontSize)
+                           .getFont());
 
         QHBoxLayout *layout = new QHBoxLayout(this);
         layout->setContentsMargins(10, 10, 10, 10);
@@ -153,11 +153,11 @@ namespace Element
     void Message::updateTextAndIcon()
     {
         QString coloredMessage = QString("<span style='color:%1'>%2</span>")
-            .arg(getColor())
+        .arg(getColor())
             .arg(_message);
 
         QString coloredParameter = QString("<span style='color:#008080'>%2</span>")
-            .arg(_paramater);
+                                       .arg(_paramater);
 
         _text->setText(coloredMessage + coloredParameter);
 
@@ -172,26 +172,19 @@ namespace Element
         switch (_placement)
         {
         case Place::Top:
+        case Place::TopLeft:
+        case Place::TopRight:
             startRect.moveTop(endRect.y() - 20);
-            _fadeIn->addAnimation(_opaAni);
             break;
 
         case Place::Bottom:
-            startRect.moveTop(endRect.y() + 20);
-            _fadeIn->addAnimation(_opaAni);
-            break;
-
-        case Place::TopLeft:
         case Place::BottomLeft:
-            startRect.moveLeft(endRect.x() - width());
-            break;
-
-        case Place::TopRight:
         case Place::BottomRight:
-            startRect.moveLeft(endRect.x() + width());
+            startRect.moveTop(endRect.y() + 20);
             break;
         }
 
+        _fadeIn->addAnimation(_opaAni);
         _moveAni->setStartValue(startRect);
         _moveAni->setEndValue(endRect);
 
@@ -268,20 +261,16 @@ namespace Element
         switch(_placement)
         {
         case Place::Top:
+        case Place::TopLeft:
+        case Place::TopRight:
             endRect = QRect(gm.x(), gm.y() - 20,
                             gm.width(), gm.height());
             break;
 
         case Place::Bottom:
-            endRect = QRect(gm.x(), gm.y() + 20,
-                            gm.width(), gm.height());
-            break;
-
-        case Place::TopLeft:
-        case Place::TopRight:
         case Place::BottomLeft:
         case Place::BottomRight:
-            endRect = QRect(gm.x(), gm.y(),
+            endRect = QRect(gm.x(), gm.y() + 20,
                             gm.width(), gm.height());
             break;
         }
@@ -297,7 +286,7 @@ namespace Element
             this->deleteLater();
         });
 
-         _fadeOut->start();
+        _fadeOut->start();
 
         if (_manager)
             _manager->removeMessage(this);

--- a/components/message.cpp
+++ b/components/message.cpp
@@ -13,65 +13,73 @@ namespace Element
 {
     QHash<QWidget*, MessageManager*> Message::_managersHash;
 
-    Message::Message(QWidget* parent, const QString& message)
-        : Message(parent, message, Type::Info, "")
+    Message::Message(const QString& message, QWidget* parent)
+        : Message(message, "", Type::Info, parent)
     {}
 
-    Message::Message(QWidget* parent, const QString& message, Type type, const QString& paramater)
-        : QWidget(parent)
-        , _message(message)
-        , _paramater(paramater)
-        , _type(type)
-        , _icon(new QLabel(this))
-        , _text(new QLabel(this))
-        , _timer(new QTimer(this))
-    {
-        _manager = getManager(parent);
+    Message::Message(const QString& message, const QString& paramater, QWidget* parent)
+        : Message(message, paramater, Type::Info, parent)
+    {}
 
-        setWindowFlags(Qt::FramelessWindowHint);
-        //setAttribute(Qt::WA_DeleteOnClose);
+    Message::Message(const QString& message, Type type, QWidget* parent)
+        : Message(message, "", type, parent)
+    {}
 
-        _text->setFont(FontHelper(_text->font())
-                           .setPointSize(Comm::defaultFontSize)
-                           .getFont());
+    Message::Message(const QString& message, const QString& paramater, Type type, QWidget* parent)
+            : QWidget(parent)
+            , _message(message)
+            , _paramater(paramater)
+            , _type(type)
+            , _icon(new QLabel(this))
+            , _text(new QLabel(this))
+            , _timer(new QTimer(this))
+        {
+            _manager = getManager(parent);
 
-        QHBoxLayout *layout = new QHBoxLayout(this);
-        layout->setContentsMargins(10, 10, 10, 10);
-        layout->setSpacing(10);
-        layout->addWidget(_icon);
-        layout->addWidget(_text);
+            setWindowFlags(Qt::FramelessWindowHint);
 
-        _close = new QLabel(this);
-        _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 16));
-        _close->setAttribute(Qt::WA_Hover);
-        _close->installEventFilter(this);
-        this->layout()->addWidget(_close);
-        _close->hide();
-        connect(_close, &QLabel::linkActivated, this, &Message::onTimeout);
+            _text->setFont(FontHelper(_text->font())
+                               .setPointSize(Comm::defaultFontSize)
+                               .getFont());
 
-        setLayout(layout);
+            QHBoxLayout *layout = new QHBoxLayout(this);
+            layout->setContentsMargins(10, 10, 10, 10);
+            layout->setSpacing(10);
+            layout->addWidget(_icon);
+            layout->addWidget(_text);
 
-        setType(_type);
-        connect(_timer, &QTimer::timeout, this, &Message::onTimeout);
+            _close = new QLabel(this);
+            _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 16));
+            _close->setAttribute(Qt::WA_Hover);
+            _close->installEventFilter(this);
+            this->layout()->addWidget(_close);
+            _close->hide();
+            connect(_close, &QLabel::linkActivated, this, &Message::onTimeout);
 
-        _opaEff = new QGraphicsOpacityEffect(this);
-        _opaEff->setOpacity(1.0);
-        setGraphicsEffect(_opaEff);
+            setLayout(layout);
 
-        _moveAni = new QPropertyAnimation(this, "geometry");
-        _moveAni->setDuration(300);
-        _moveAni->setEasingCurve(QEasingCurve::InOutCubic);
+            setType(_type);
+            connect(_timer, &QTimer::timeout, this, &Message::onTimeout);
 
-        _opaAni = new QPropertyAnimation(_opaEff, "opacity");
-        _opaAni->setDuration(300);
-        _opaAni->setStartValue(0.0);
-        _opaAni->setEndValue(1.0);
+            _opaEff = new QGraphicsOpacityEffect(this);
+            _opaEff->setOpacity(0.0);
+            setGraphicsEffect(_opaEff);
 
-        _fadeIn = new QParallelAnimationGroup(this);
-        _fadeIn->addAnimation(_moveAni);
+            _moveAni = new QPropertyAnimation(this, "geometry");
+            _moveAni->setDuration(300);
+            _moveAni->setEasingCurve(QEasingCurve::OutCubic);
 
-        _fadeOut = new QParallelAnimationGroup(this);
-    }
+            _opaAni = new QPropertyAnimation(_opaEff, "opacity");
+            _opaAni->setDuration(300);
+            _opaAni->setStartValue(0.0);
+            _opaAni->setEndValue(1.0);
+            _moveAni->setEasingCurve(QEasingCurve::OutCubic);
+
+            _fadeIn = new QParallelAnimationGroup(this);
+            _fadeIn->addAnimation(_moveAni);
+
+            _fadeOut = new QParallelAnimationGroup(this);
+        }
 
     void Message::show()
     {

--- a/components/message.cpp
+++ b/components/message.cpp
@@ -1,4 +1,5 @@
 #include "message.h"
+#include "messagemanager.h"
 #include "private/utils.h"
 #include "icon.h"
 
@@ -8,23 +9,15 @@
 #include <QHash>
 #include <QPainterPath>
 
-
-
 namespace Element
 {
-    Message::Message(const QString& message, QWidget* parent)
-        : Message(message, "", Type::Info, parent)
+    QHash<QWidget*, MessageManager*> Message::_managersHash;
+
+    Message::Message(QWidget* parent, const QString& message)
+        : Message(parent, message, Type::Info, "")
     {}
 
-    Message::Message(const QString& message, const QString& paramater, QWidget* parent)
-        : Message(message, paramater, Type::Info, parent)
-    {}
-
-    Message::Message(const QString& message, Message::Type type, QWidget* parent)
-        : Message(message, "", type, parent)
-    {}
-
-    Message::Message(const QString& message, const QString& paramater, Type type, QWidget* parent)
+    Message::Message(QWidget* parent, const QString& message, Type type, const QString& paramater)
         : QWidget(parent)
         , _message(message)
         , _paramater(paramater)
@@ -33,8 +26,10 @@ namespace Element
         , _text(new QLabel(this))
         , _timer(new QTimer(this))
     {
+        _manager = getManager(parent);
+
         setWindowFlags(Qt::FramelessWindowHint);
-        setAttribute(Qt::WA_DeleteOnClose);
+        //setAttribute(Qt::WA_DeleteOnClose);
 
         _text->setFont(FontHelper(_text->font())
                 .setPointSize(Comm::defaultFontSize)
@@ -46,17 +41,47 @@ namespace Element
         layout->addWidget(_icon);
         layout->addWidget(_text);
 
+        _close = new QLabel(this);
+        _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 16));
+        _close->setAttribute(Qt::WA_Hover);
+        _close->installEventFilter(this);
+        this->layout()->addWidget(_close);
+        _close->hide();
+        connect(_close, &QLabel::linkActivated, this, &Message::onTimeout);
+
         setLayout(layout);
 
         setType(_type);
         connect(_timer, &QTimer::timeout, this, &Message::onTimeout);
+
+        _opaEff = new QGraphicsOpacityEffect(this);
+        _opaEff->setOpacity(1.0);
+        setGraphicsEffect(_opaEff);
+
+        _moveAni = new QPropertyAnimation(this, "geometry");
+        _moveAni->setDuration(300);
+        _moveAni->setEasingCurve(QEasingCurve::InOutCubic);
+
+        _opaAni = new QPropertyAnimation(_opaEff, "opacity");
+        _opaAni->setDuration(300);
+        _opaAni->setStartValue(0.0);
+        _opaAni->setEndValue(1.0);
+
+        _fadeIn = new QParallelAnimationGroup(this);
+        _fadeIn->addAnimation(_moveAni);
+
+        _fadeOut = new QParallelAnimationGroup(this);
     }
 
     void Message::show()
     {
+        if(_manager)
+            _manager->addMessage(this);
+
         updatePosition();
-        QWidget::show();
-        _timer->start(_duration);
+
+        if(_duration>0&&_autoClose)
+            _timer->start(_duration);
     }
 
     Message& Message::setMessage(const QString& message)
@@ -90,11 +115,20 @@ namespace Element
         return *this;
     }
 
-    Message& Message::setShowClose(bool showClose, bool autoClose)
+    Message& Message::setShowClose(bool showClose)
     {
-        _showClose = showClose;
-        if (!autoClose)
-        {}
+        if(showClose)
+            _close->show();
+        else
+            _close->hide();
+
+        adjustSize();
+        return *this;
+    }
+
+    Message& Message::setAutoClose(bool autoClose)
+    {
+        _autoClose = autoClose;
         return *this;
     }
 
@@ -107,6 +141,12 @@ namespace Element
     Message& Message::setDuration(int msec)
     {
         _duration = msec;
+        return *this;
+    }
+
+    Message& Message::setOnClose(bool onClose)
+    {
+        _onClose = onClose;
         return *this;
     }
 
@@ -126,37 +166,37 @@ namespace Element
 
     void Message::updatePosition()
     {
-        QRect parentRect = parentWidget()->geometry();
-        QSize widgetSize = size();
+        QRect endRect = geometry();
+        QRect startRect = endRect;
 
-        int x = 0, y = 0;
+        switch (_placement)
+        {
+        case Place::Top:
+            startRect.moveTop(endRect.y() - 20);
+            _fadeIn->addAnimation(_opaAni);
+            break;
 
-        if (_placement == Place::Top) {
-            x = (parentRect.width() - widgetSize.width()) / 2;
-            y = 10 + (10 + widgetSize.height()) * _count[Place::Top]++;
-        }
-        else if (_placement == Place::TopLeft) {
-            x = 10;
-            y = 10 + (10 + widgetSize.height()) * _count[Place::TopLeft]++;
-        }
-        else if (_placement == Place::TopRight) {
-            x = parentRect.width() - widgetSize.width() - 10;
-            y = 10 + (10 + widgetSize.height()) * _count[Place::TopRight]++;
-        }
-        else if (_placement == Place::Bottom) {
-            x = (parentRect.width() - widgetSize.width()) / 2;
-            y = parentRect.height() - (widgetSize.height() + 10) * ++_count[Place::Bottom];
-        }
-        else if (_placement == Place::BottomLeft) {
-            x = 10;
-            y = parentRect.height() - (widgetSize.height() + 10) * ++_count[Place::BottomLeft];
-        }
-        else if (_placement == Place::BottomRight) {
-            x = parentRect.width() - widgetSize.width() - 10;
-            y = parentRect.height() - (widgetSize.height() + 10) * ++_count[Place::BottomRight];
+        case Place::Bottom:
+            startRect.moveTop(endRect.y() + 20);
+            _fadeIn->addAnimation(_opaAni);
+            break;
+
+        case Place::TopLeft:
+        case Place::BottomLeft:
+            startRect.moveLeft(endRect.x() - width());
+            break;
+
+        case Place::TopRight:
+        case Place::BottomRight:
+            startRect.moveLeft(endRect.x() + width());
+            break;
         }
 
-        move(x, y);
+        _moveAni->setStartValue(startRect);
+        _moveAni->setEndValue(endRect);
+
+        QWidget::show();
+        _fadeIn->start();
     }
 
     QString Message::getColor()
@@ -211,10 +251,56 @@ namespace Element
         return QPixmap();
     }
 
+    Message::Place Message::getPlacement()
+    {
+        return _placement;
+    }
+
     void Message::onTimeout()
     {
-        _count[_placement]--;
-        QWidget::close();
+        _opaAni->setStartValue(1.0);
+        _opaAni->setEndValue(0.0);
+        _fadeOut->addAnimation(_opaAni);
+
+        QRect gm = geometry();
+        QRect endRect;
+
+        switch(_placement)
+        {
+        case Place::Top:
+            endRect = QRect(gm.x(), gm.y() - 20,
+                            gm.width(), gm.height());
+            break;
+
+        case Place::Bottom:
+            endRect = QRect(gm.x(), gm.y() + 20,
+                            gm.width(), gm.height());
+            break;
+
+        case Place::TopLeft:
+        case Place::TopRight:
+        case Place::BottomLeft:
+        case Place::BottomRight:
+            endRect = QRect(gm.x(), gm.y(),
+                            gm.width(), gm.height());
+            break;
+        }
+
+        _moveAni->setStartValue(gm);
+        _moveAni->setEndValue(endRect);
+        _fadeOut->addAnimation(_moveAni);
+
+        connect(_fadeOut, &QParallelAnimationGroup::finished, this, [this]() {
+            if(_onClose)
+                emit close();
+
+            this->deleteLater();
+        });
+
+         _fadeOut->start();
+
+        if (_manager)
+            _manager->removeMessage(this);
     }
 
     void Message::paintEvent(QPaintEvent *event)
@@ -235,5 +321,53 @@ namespace Element
         painter.drawRoundedRect(rect().adjusted(0, 0, 0, 0), 4, 4, Qt::AbsoluteSize);
 
         QWidget::paintEvent(event);
+    }
+
+    void Message::stopFadeIn()
+    {
+        if (_fadeIn->state() == QAbstractAnimation::Running)
+            _fadeIn->stop();
+
+        _opaEff->setOpacity(1.0);
+    }
+
+    bool Message::eventFilter(QObject* watched, QEvent* event)
+    {
+        if (watched == _close)
+        {
+            if (event->type() == QEvent::HoverEnter)
+            {
+                _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::regularText(), 16));
+                _close->setCursor(Qt::PointingHandCursor);
+                return true;
+            }
+            else if (event->type() == QEvent::HoverLeave)
+            {
+                _close->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::secondaryText(), 16));
+                _close->setCursor(Qt::ArrowCursor);
+                return true;
+            }
+            else if (event->type() == QEvent::MouseButtonPress)
+            {
+                emit _close->linkActivated("");
+            }
+        }
+        return QWidget::eventFilter(watched, event);
+    }
+
+    MessageManager* Message::getManager(QWidget* parent)
+    {
+        auto it = _managersHash.find(parent);
+        if (it != _managersHash.end())
+            return it.value();
+
+        MessageManager* mgr = new MessageManager(parent);
+        _managersHash.insert(parent, mgr);
+
+        QObject::connect(parent, &QWidget::destroyed, [parent](){
+            _managersHash.remove(parent);
+        });
+
+        return mgr;
     }
 }

--- a/components/message.h
+++ b/components/message.h
@@ -53,8 +53,10 @@ namespace Element
         Message& setOnClose(bool onClose);
 
     public:
-        Message(QWidget* parent, const QString& message);
-        Message(QWidget* parent, const QString& message, Type type, const QString& paramater = "");
+        Message(const QString& message, QWidget* parent = nullptr);
+        Message(const QString& message, const QString& paramater, QWidget* parent = nullptr);
+        Message(const QString& message, Type type = Type::Info, QWidget* parent = nullptr);
+        Message(const QString& message, const QString& paramater, Type type = Type::Info, QWidget* parent = nullptr);
 
         void show();
         static MessageManager* getManager(QWidget* parent);

--- a/components/message.h
+++ b/components/message.h
@@ -6,12 +6,20 @@
 #include <QString>
 #include <QLabel>
 #include <QHash>
+#include <QPoint>
+#include <QPropertyAnimation>
+#include <QGraphicsOpacityEffect>
+#include <QParallelAnimationGroup>
 
 namespace Element
 {
+    class MessageManager;
+
     class Message : public QWidget
     {
-    Q_OBJECT
+        Q_OBJECT
+
+        friend class MessageManager;
 
     public:
         enum class Type
@@ -36,20 +44,23 @@ namespace Element
     public:
         Message& setMessage(const QString& message);
         Message& setParamater(const QString& paramater);
-
         Message& setType(Type type);
         Message& setPlain(bool plain);
-        Message& setShowClose(bool showClose, bool autoClose = true);
+        Message& setShowClose(bool showClose);
+        Message& setAutoClose(bool autoClose);
         Message& setPlacement(Place place);
         Message& setDuration(int msec);
+        Message& setOnClose(bool onClose);
 
     public:
-        Message(const QString& message, QWidget* parent = nullptr);
-        Message(const QString& message, const QString& paramater, QWidget* parent = nullptr);
-        Message(const QString& message, Type type = Type::Info, QWidget* parent = nullptr);
-        Message(const QString& message, const QString& paramater, Type type = Type::Info, QWidget* parent = nullptr);
+        Message(QWidget* parent, const QString& message);
+        Message(QWidget* parent, const QString& message, Type type, const QString& paramater = "");
 
         void show();
+        static MessageManager* getManager(QWidget* parent);
+
+    signals:
+        void close();
 
     private:
         void updateTextAndIcon();
@@ -59,11 +70,14 @@ namespace Element
         QString getBorderColor();
         QString getBackgroundColor();
         QPixmap getIcon();
+        Place getPlacement();
 
+        void stopFadeIn();
         void onTimeout();
 
     protected:
         void paintEvent(QPaintEvent *event) override;
+        bool eventFilter(QObject* watched, QEvent* event) override;
 
     private:
         QString _message;
@@ -73,20 +87,27 @@ namespace Element
         Type _type = Type::Info;
         Place _placement = Place::Top;
         bool _plain = false;
-        bool _showClose = false;
+        bool _onClose = false;
+        bool _autoClose = true;
         int _duration = 3000;
 
     private:
         QSSHelper _qsshelper;
         QLabel* _icon;
         QLabel* _text;
+        QLabel* _close;
         QTimer* _timer;
-        static QHash<Place, int> _count;
+        QPropertyAnimation* _opaAni;
+        QPropertyAnimation* _moveAni;
+        QGraphicsOpacityEffect* _opaEff;
+        QParallelAnimationGroup* _fadeIn;
+        QParallelAnimationGroup* _fadeOut;
+
+        MessageManager* _manager; 
+        static QHash<QWidget*, MessageManager*> _managersHash;
     };
 
     inline uint qHash(Message::Place key, uint seed = 0) noexcept {
         return static_cast<uint>(std::hash<int>{}(static_cast<int>(key))) ^ seed;
     }
-
-    inline QHash<Message::Place, int> Message::_count;
 }

--- a/components/messagemanager.cpp
+++ b/components/messagemanager.cpp
@@ -1,0 +1,188 @@
+#include "messagemanager.h"
+
+namespace Element
+{
+    MessageManager::MessageManager(QWidget* parent)
+        : QObject(parent)
+    {
+        Q_ASSERT(parent);
+        Message::_managersHash[parent] = this;
+    }
+
+    MessageManager::~MessageManager()
+    {
+        for (auto& list : _messagesList)
+        {
+            for (Message* msg : list)
+            {
+                msg->close();
+            }
+            list.clear();
+        }
+        _messagesList.clear();
+    }
+
+    void MessageManager::addMessage(Message* msg)
+    {
+        if(!msg) return;
+
+        QWidget* pw = qobject_cast<QWidget*>(parent());
+
+        if (msg->parentWidget() != pw)
+            msg->setParent(pw);
+
+        Message::Place place = msg->getPlacement();
+        _messagesList[place].append(msg);
+
+        msg->setGeometry(calNewMsgGeometry(msg));
+    }
+
+    void MessageManager::removeMessage(Message* msg)
+    {
+        if (!msg) return;
+
+        Message::Place place = msg->getPlacement();
+        QList<Message*>& list = _messagesList[place];
+        int index = list.indexOf(msg);
+        if (index != -1)
+        {
+            list.removeAt(index);
+            if (!list.isEmpty())
+                adjust(place);
+        }
+    }
+
+    void MessageManager::adjust(Message::Place placement)
+    {
+        QList<Message*>& list = _messagesList[placement];
+        if (list.isEmpty()) return;
+
+        QWidget* pw = qobject_cast<QWidget*>(parent());
+        if (!pw) return;
+
+        bool topAligned = (placement == Message::Place::Top ||
+                           placement == Message::Place::TopLeft ||
+                           placement == Message::Place::TopRight);
+        int startY = topAligned ? _offset : (pw->height() - _offset);
+        int curY = startY;
+
+        for (int i = 0; i < list.size(); ++i)
+        {
+            Message* msg = list[i];
+            int w = msg->width();
+            int h = msg->height();
+
+            int x = 0, y;
+            switch (placement)
+            {
+            case Message::Place::Top:
+            case Message::Place::Bottom:
+                x = (pw->width() - w) / 2;
+                break;
+            case Message::Place::TopLeft:
+            case Message::Place::BottomLeft:
+                x = 10;
+                break;
+            case Message::Place::TopRight:
+            case Message::Place::BottomRight:
+                x = pw->width() - w - 10;
+                break;
+            }
+
+            if (topAligned)
+            {
+                y = curY;
+                curY += h + 10;
+            }
+            else
+            {
+                y = curY - h;
+                curY -= (h + 10);
+            }
+
+            QRect newRect(x, y, w, h);
+            QRect oldRect = msg->geometry();
+            if (oldRect != newRect)
+            {
+                msg->stopFadeIn();
+                QPropertyAnimation* anim = new QPropertyAnimation(msg, "geometry");
+                anim->setDuration(300);
+                anim->setEasingCurve(QEasingCurve::OutCubic);
+                anim->setStartValue(oldRect);
+                anim->setEndValue(newRect);
+                anim->start(QAbstractAnimation::DeleteWhenStopped);
+            }
+        }
+    }
+
+    QRect MessageManager::calNewMsgGeometry(Message* msg) const
+    {
+        QWidget* pw = qobject_cast<QWidget*>(parent());
+        if (!pw) return QRect();
+
+        Message::Place place = msg->_placement;
+        const QList<Message*>& list = _messagesList[place];
+
+        int index = list.size() - 1;
+
+        QSize msgSize = msg->size();
+        int x = 0;
+        int y = 0;
+
+        switch (place)
+        {
+        case Message::Place::Top:
+        case Message::Place::Bottom:
+            x = (pw->width() - msgSize.width()) / 2;
+            break;
+        case Message::Place::TopLeft:
+        case Message::Place::BottomLeft:
+            x = 10;
+            break;
+        case Message::Place::TopRight:
+        case Message::Place::BottomRight:
+            x = pw->width() - msgSize.width() - 10;
+            break;
+        }
+
+        int yOffset = _offset;
+        bool topAligned = (place == Message::Place::Top ||
+                           place == Message::Place::TopLeft ||
+                           place == Message::Place::TopRight);
+
+        if (topAligned)
+        {
+            for (int i = 0; i < index; ++i)
+                yOffset += list[i]->height() + 10;
+
+            y = yOffset;
+        }
+        else
+        {
+            int totalHeight = 0;
+            for (int i = 0; i <= index; ++i)
+                totalHeight += list[i]->height() + 10;
+
+            totalHeight -= 10;
+            y = pw->height() - _offset - totalHeight;
+        }
+
+        return QRect(x, y, msgSize.width(), msgSize.height());
+    }
+
+    void MessageManager::stopMsgFadeIn(Message* msg)
+    {
+        msg->stopFadeIn();
+    }
+
+    Message::Place MessageManager::getMsgPlacement(Message* msg)
+    {
+        return msg->getPlacement();
+    }
+
+    MessageManager& MessageManager::setOffset(int offset)
+    {
+        _offset = offset;
+        return *this;
+    }
+}

--- a/components/messagemanager.cpp
+++ b/components/messagemanager.cpp
@@ -5,7 +5,6 @@ namespace Element
     MessageManager::MessageManager(QWidget* parent)
         : QObject(parent)
     {
-        Q_ASSERT(parent);
         Message::_managersHash[parent] = this;
     }
 
@@ -28,6 +27,8 @@ namespace Element
 
         QWidget* pw = qobject_cast<QWidget*>(parent());
 
+        if(!pw) return;
+
         if (msg->parentWidget() != pw)
             msg->setParent(pw);
 
@@ -40,6 +41,10 @@ namespace Element
     void MessageManager::removeMessage(Message* msg)
     {
         if (!msg) return;
+
+        QWidget* pw = qobject_cast<QWidget*>(parent());
+
+        if(!pw) return;
 
         Message::Place place = msg->getPlacement();
         QList<Message*>& list = _messagesList[place];

--- a/components/messagemanager.cpp
+++ b/components/messagemanager.cpp
@@ -63,8 +63,7 @@ namespace Element
         bool topAligned = (placement == Message::Place::Top ||
                            placement == Message::Place::TopLeft ||
                            placement == Message::Place::TopRight);
-        int startY = topAligned ? _offset : (pw->height() - _offset);
-        int curY = startY;
+        int curY = topAligned ? _offset : (pw->height() - _offset);
 
         for (int i = 0; i < list.size(); ++i)
         {

--- a/components/messagemanager.h
+++ b/components/messagemanager.h
@@ -1,5 +1,4 @@
-#ifndef MESSAGEMANAGER_H
-#define MESSAGEMANAGER_H
+#pragma once
 
 #include "message.h"
 
@@ -43,5 +42,3 @@ namespace Element
         virtual QRect calNewMsgGeometry(Message* msg) const;
     };
 }
-
-#endif // MESSAGEMANAGER_H

--- a/components/messagemanager.h
+++ b/components/messagemanager.h
@@ -1,0 +1,47 @@
+#ifndef MESSAGEMANAGER_H
+#define MESSAGEMANAGER_H
+
+#include "message.h"
+
+#include <QObject>
+#include <QHash>
+#include <QList>
+#include <QPropertyAnimation>
+#include <QApplication>
+#include <QScreen>
+
+/* The MessageManager class is responsible for managing the positional information of Message objects.
+ * When using this class, a non‑null parent widget is required. */
+
+namespace Element
+{
+    class MessageManager : public QObject
+    {
+    Q_OBJECT
+
+    public:
+        MessageManager& setOffset(int offset);
+        void addMessage(Element::Message* msg);
+        void removeMessage(Element::Message* msg);
+
+    public:
+        MessageManager(QWidget* parent);
+        virtual ~MessageManager();
+
+    private:
+        int _offset = 20;
+
+    private:
+        QHash<Element::Message::Place, QList<Element::Message*>> _messagesList;
+
+    protected:
+        Message::Place getMsgPlacement(Message* msg);
+        void stopMsgFadeIn(Message* msg);
+
+    protected:
+        virtual void adjust(Element::Message::Place placement);
+        virtual QRect calNewMsgGeometry(Message* msg) const;
+    };
+}
+
+#endif // MESSAGEMANAGER_H

--- a/components/notification.cpp
+++ b/components/notification.cpp
@@ -119,9 +119,12 @@ namespace Element
 
     Notification& Notification::setShowClose(bool showClose, bool autoClose)
     {
-        _showClose = showClose;
-        if (!autoClose)
-        {}
+        if(!showClose)
+            _close->hide();
+        else
+            _close->show();
+
+        adjustSize();
         return *this;
     }
 

--- a/components/notification.h
+++ b/components/notification.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QLabel>
 #include <QHash>
+#include <QBoxLayout>
 
 namespace Element
 {
@@ -67,7 +68,6 @@ namespace Element
     private:
         Type _type = Type::Defualt;
         Position _positon = Position::TopRight;
-        bool _showClose = true;
         int _duration = 4500;
         int _offset = 10;
 

--- a/components/popconfirm.h
+++ b/components/popconfirm.h
@@ -5,7 +5,7 @@
 namespace Element
 {
 
-    class PopConfirm : public QWidget
+    class Popconfirm : public QWidget
     {
     Q_OBJECT
     public:

--- a/components/popover.cpp
+++ b/components/popover.cpp
@@ -1,6 +1,93 @@
-#include "popover.h"
+// #include "popover.h"
+// #include "color.h"
 
-namespace Element
-{
+// namespace Element
+// {
+//     Popover& Popover::setPlacement(Placement placement)
+//     {
+//         _placement = placement;
+//         return *this;
+//     }
 
-}
+//     Popover& Popover::setEffect(Effect effect)
+//     {
+//         _effect = effect;
+
+//         if (effect == Effect::Dark)
+//         {
+//             _qsshelper.setProperty("QLabel", "color", Color::basicWhite());
+//             _arrow->setColor(Color::primaryText());
+//             _arrow->setBorder("");
+//         }
+//         else
+//         {
+//             _qsshelper.setProperty("QLabel", "color", Color::basicBlack());
+//             _arrow->setColor(Color::basicWhite());
+//             _arrow->setBorder(Color::darkBorder());
+//         }
+
+//         _qsshelper.setProperty("QLabel", "padding", "7px 11px");
+
+//         //_label->setStyleSheet(_qsshelper.generate());
+//         adjustSize();
+//         update();
+
+//         return *this;
+//     }
+
+//     Popover& Popover::setTrigger(Trigger trigger)
+//     {
+//         _trigger = trigger;
+//         return *this;
+//     }
+
+//     Popover& Popover::setText(const QString& text)
+//     {
+//         //_label->setText(text);
+//         //_label->adjustSize();
+//         adjustSize();
+//         return *this;
+//     }
+
+//     Popover& Popover::setDisabled(bool disabled)
+//     {
+//         QWidget::setDisabled(disabled);
+//         return *this;
+//     }
+
+//     Popover& Popover::setOffset(int offset)
+//     {
+//         _offset = offset;
+//         return *this;
+//     }
+
+//     Popover& Popover::setShowAfter(int msec)
+//     {
+//         _showAfter = msec;
+//         return *this;
+//     }
+
+//     Popover& Popover::setHideAfter(int msec)
+//     {
+//         _hideAfter = msec;
+//         return *this;
+//     }
+
+//     Popover& Popover::setShowArrow(bool showArrow)
+//     {
+//         _showArrow = showArrow;
+//         return *this;
+//     }
+
+//     Popover& Popover::setAutoClose(int duration)
+//     {
+//         _duration = duration;
+//         return *this;
+//     }
+
+//     Popover& Popover::setEnterable(bool enterable)
+//     {
+//         _enterable = enterable;
+//         return *this;
+//     }
+// }

--- a/components/popover.h
+++ b/components/popover.h
@@ -5,7 +5,7 @@
 namespace Element
 {
 
-    class PopOver : public QWidget
+    class Popover : public QWidget
     {
     Q_OBJECT
     public:

--- a/components/popover.h
+++ b/components/popover.h
@@ -1,18 +1,93 @@
-#pragma once
+// #pragma once
 
-#include <QWidget>
+// #include "tooltip.h"
 
-namespace Element
-{
+// #include <QWidget>
 
-    class Popover : public QWidget
-    {
-    Q_OBJECT
-    public:
-    public:
-    public:
-    private:
-    private:
-    };
+// namespace Element
+// {
+//     class Popover : public QWidget
+//     {
+//     Q_OBJECT
 
-}
+//     public:
+//         enum class Placement
+//         {
+//             Top, TopStart, TopEnd,
+//             Left, LeftStart, LeftEnd,
+//             Right, RightStart, RightEnd,
+//             Bottom, BottomStart, BottomEnd,
+//         };
+
+//         enum class Effect { Dark, Light, };
+
+//         enum class Trigger { Hover, Click, Focus, ContextMenu };
+
+//     public:
+//         Popover& setPlacement(Placement placement);
+//         Popover& setEffect(Effect effect);
+//         Popover& setTrigger(Trigger trigger);
+//         Popover& setText(const QString& text);
+//         Popover& setDisabled(bool disabled);
+//         Popover& setOffset(int offset);
+//         Popover& setShowAfter(int msec);
+//         Popover& setHideAfter(int msec);
+//         Popover& setShowArrow(bool showArrow);
+//         Popover& setAutoClose(int duration);
+//         Popover& setEnterable(bool enterable);
+
+//         Placement getPlacement();
+
+//         bool isDisabled();
+
+//         Popover& setMoveable(bool moveable);
+//         Popover& setPosition(const QPoint& start);
+
+//     public:
+//         void show();
+//         void hide();
+//         void setVisible(bool visible) override;
+
+//     public:
+//         Popover(const QString& text, QWidget* target);
+//         Popover(const QString& text, Effect effect, QWidget* target);
+//         Popover(const QString& text, Placement placement, QWidget* target);
+//         Popover(const QString& text, Placement placement, Effect effect, QWidget* target);
+
+//     protected:
+//         void showEvent(QShowEvent* event) override;
+//         void hideEvent(QHideEvent* event) override;
+//         void paintEvent(QPaintEvent* event) override;
+//         bool eventFilter(QObject* obj, QEvent* event) override;
+
+//     private:
+//         void updatePosition();
+//         Placement checkPlacement();
+
+//     private:
+//         Placement _placement = Placement::Top;
+//         Effect _effect = Effect::Dark;
+//         Trigger _trigger = Trigger::Hover;
+
+//         int _offset = 15;
+//         int _showAfter = 0;
+//         int _hideAfter = 200;
+//         bool _showArrow = true;
+//         bool _duration = 0;
+//         bool _enterable = true;
+
+//         bool _moveable = false;
+
+//     private:
+//         QWidget* _target = nullptr;
+//         QWidget* _content = nullptr;
+//         Arrow* _arrow = nullptr;
+
+//         QTimer* _showTimer = nullptr;
+//         QTimer* _hideTimer = nullptr;
+//         QTimer* _autoCloseTimer = nullptr;
+
+//         QSSHelper _qsshelper;
+//     };
+
+// }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -315,62 +315,74 @@ void Example::setupTab5()
 
     connect(ui->button_42, &Button::clicked, this, [&]() {
         Dialog* dialog = new Dialog("Tips", "this is a message dialog", this);
+
+        dialog->setBeforeClose([](std::function<void()> done) {
+            Dialog* qryDlg = new Dialog;
+            qryDlg->setTitle("").setContent("Are you sure to close this dialog?");
+            QObject::connect(qryDlg, &Element::Dialog::accepted, [done]() {
+                done();
+            });
+            QObject::connect(qryDlg, &Element::Dialog::rejected, []() {});
+            QObject::connect(qryDlg, &Element::Dialog::closed, []() {});
+            qryDlg->show();
+        });
+
         dialog->show();
     });
     connect(ui->button_43, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message.", Message::Type::Info, " VNode");
+        Message* message = new Message("This is a message.", " VNode", this);
         message->setType(Message::Type::Info);
         message->show();
     });
     connect(ui->button_44, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message on top left.");
+        Message* message = new Message("This is a message on top left.", this);
         message->setPlacement(Message::Place::TopLeft);
         message->show();
     });
     connect(ui->button_45, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message on top right.");
+        Message* message = new Message("This is a message on top right.", this);
         message->setPlacement(Message::Place::TopRight);
         message->show();
     });
     connect(ui->button_46, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message on bottom.");
+        Message* message = new Message("This is a message on bottom.", this);
         message->setPlacement(Message::Place::Bottom);
         message->show();
     });
     connect(ui->button_47, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message on bottom left.");
+        Message* message = new Message("This is a message on bottom left.", this);
         message->setPlacement(Message::Place::BottomLeft);
         message->show();
     });
     connect(ui->button_48, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a message on bottom right.");
+        Message* message = new Message("This is a message on bottom right.", this);
         message->setPlacement(Message::Place::BottomRight);
         message->show();
     });
     connect(ui->button_49, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a primary message.", Message::Type::Primary);
+        Message* message = new Message("This is a primary message.", Message::Type::Primary, this);
         message->show();
     });
     connect(ui->button_50, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a success message.", Message::Type::Success);
+        Message* message = new Message("This is a success message.", Message::Type::Success, this);
         message->show();
     });
     connect(ui->button_51, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a warning message.", Message::Type::Warning);
+        Message* message = new Message("This is a warning message.", Message::Type::Warning, this);
         message->show();
     });
     connect(ui->button_52, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a info message.", Message::Type::Info);
+        Message* message = new Message("This is a info message.", Message::Type::Info, this);
         message->show();
     });
     connect(ui->button_53, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "This is a error message.", Message::Type::Error);
+        Message* message = new Message("This is a error message.", Message::Type::Error, this);
         message->show();
     });
 
     //带回调函数
     connect(ui->button_65, &Button::clicked, this, [&]() {
-        Message* message = new Message(this, "Terminal output a message.");
+        Message* message = new Message("Terminal output a message.", this);
         message->setAutoClose(false);
         message->setOnClose(true);
         message->setShowClose(true);

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -14,6 +14,7 @@
 #include "badge.h"
 #include "shadow.h"
 #include "tooltip.h"
+#include "divider.h"
 
 #include <QDebug>
 #include <QTimer>
@@ -131,6 +132,34 @@ void Example::setupTab0()
     ShadowEf::setShadow(ui->shadow_2, ShadowEf::Type::Light);
     ShadowEf::setShadow(ui->shadow_3, ShadowEf::Type::Lighter);
     ShadowEf::setShadow(ui->shadow_4, ShadowEf::Type::Dark);
+
+    QVBoxLayout* layout1 = new QVBoxLayout(ui->widget_1);
+    layout1->addWidget(ui->dividerText_1);
+    layout1->addWidget(new HDivider(ui->widget_1));
+    layout1->addWidget(ui->dividerText_2);
+
+    QHBoxLayout* layout2 = new QHBoxLayout(ui->widget_3);
+    layout2->addWidget(ui->dividerText_6);
+    VDivider* v = new VDivider(ui->widget_3);
+    v->setLineStyle(Divider::LineStyle::Solid).setLineColor("#dcdfe6");
+    layout2->addWidget(v);
+    layout2->addWidget(ui->dividerText_7);
+    layout2->addWidget(new VDivider(ui->widget_3));
+    layout2->addWidget(ui->dividerText_8);
+
+    QVBoxLayout* layout3 = new QVBoxLayout(ui->widget_2);
+    layout3->addWidget(ui->dividerText_3);
+    layout3->addWidget(new HDivider("少年包青天", HDivider::ContentPosition::Left));
+    layout3->addWidget(ui->dividerText_4);
+    layout3->addWidget(new HDivider(Icon::instance().getPixmap(Icon::Monitor, Color::basicBlack(), 18)));
+    layout3->addWidget(ui->dividerText_5);
+    HDivider* hd = new HDivider(ui->widget_2);
+    hd->setText("阿里云")
+        .setContentPosition(HDivider::ContentPosition::Right)
+        .setSpacing(20)
+        .setLineStyle(Divider::LineStyle::Solid)
+        .setLineColor("#dcdfe6");
+    layout3->addWidget(hd);
 }
 
 void Example::setupTab1()
@@ -277,60 +306,80 @@ void Example::setupTab4()
 
 void Example::setupTab5()
 {
+    /* If you need to set the offset for Message objects,
+     * you must either instantiate a MessageManager object in advance,
+        or call the getManager method on a Message object to obtain the MessageManager instance. */
+
+    // MessageManager* _msgManager = new MessageManager(this);
+    // _msgManager->setOffset(20);
+
     connect(ui->button_42, &Button::clicked, this, [&]() {
         Dialog* dialog = new Dialog("Tips", "this is a message dialog", this);
         dialog->show();
     });
     connect(ui->button_43, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message.", " VNode", this);
+        Message* message = new Message(this, "This is a message.", Message::Type::Info, " VNode");
         message->setType(Message::Type::Info);
         message->show();
     });
     connect(ui->button_44, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message on top left.", this);
+        Message* message = new Message(this, "This is a message on top left.");
         message->setPlacement(Message::Place::TopLeft);
         message->show();
     });
     connect(ui->button_45, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message on top right.", this);
+        Message* message = new Message(this, "This is a message on top right.");
         message->setPlacement(Message::Place::TopRight);
         message->show();
     });
     connect(ui->button_46, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message on bottom.", this);
+        Message* message = new Message(this, "This is a message on bottom.");
         message->setPlacement(Message::Place::Bottom);
         message->show();
     });
     connect(ui->button_47, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message on bottom left.", this);
+        Message* message = new Message(this, "This is a message on bottom left.");
         message->setPlacement(Message::Place::BottomLeft);
         message->show();
     });
     connect(ui->button_48, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a message on bottom right.", this);
+        Message* message = new Message(this, "This is a message on bottom right.");
         message->setPlacement(Message::Place::BottomRight);
         message->show();
     });
     connect(ui->button_49, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a primary message.", Message::Type::Primary, this);
+        Message* message = new Message(this, "This is a primary message.", Message::Type::Primary);
         message->show();
     });
     connect(ui->button_50, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a success message.", Message::Type::Success, this);
+        Message* message = new Message(this, "This is a success message.", Message::Type::Success);
         message->show();
     });
     connect(ui->button_51, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a warning message.", Message::Type::Warning, this);
+        Message* message = new Message(this, "This is a warning message.", Message::Type::Warning);
         message->show();
     });
     connect(ui->button_52, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a info message.", Message::Type::Info, this);
+        Message* message = new Message(this, "This is a info message.", Message::Type::Info);
         message->show();
     });
     connect(ui->button_53, &Button::clicked, this, [&]() {
-        Message* message = new Message("This is a error message.", Message::Type::Error, this);
+        Message* message = new Message(this, "This is a error message.", Message::Type::Error);
         message->show();
     });
+
+    //带回调函数
+    connect(ui->button_65, &Button::clicked, this, [&]() {
+        Message* message = new Message(this, "Terminal output a message.");
+        message->setAutoClose(false);
+        message->setOnClose(true);
+        message->setShowClose(true);
+        connect(message, &Message::close, this, [](){
+            qDebug()<<"The Message is closed;";
+        });
+        message->show();
+    });
+
     connect(ui->button_54, &Button::clicked, this, [&]() {
         Notification* noti = new Notification("Title", "This is a reminder.", this);
         noti->show();
@@ -573,7 +622,6 @@ void Example::setupTab11()
     ui->carousel->addImage(QPixmap(":/icons/other/hamburger.png"));
     ui->carousel->addImage(QPixmap(":/icons/other/square-default-avatar.png"));
     ui->carousel->addImage(QPixmap(":/icons/other/example-avatar.png"));
-
 }
 
 Example::~Example()

--- a/example/example.h
+++ b/example/example.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "icon.h"
+#include "messagemanager.h"
 
 #include <QMainWindow>
 
@@ -37,4 +38,5 @@ private:
 
 private:
     Ui::Example *ui;
+
 };

--- a/example/example.ui
+++ b/example/example.ui
@@ -48,89 +48,11 @@
      <attribute name="title">
       <string>文本</string>
      </attribute>
-     <widget class="Element::Text" name="defaultText">
-      <property name="geometry">
-       <rect>
-        <x>70</x>
-        <y>70</y>
-        <width>65</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Default</string>
-      </property>
-     </widget>
-     <widget class="Element::Text" name="primaryText">
-      <property name="geometry">
-       <rect>
-        <x>170</x>
-        <y>70</y>
-        <width>71</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Primary</string>
-      </property>
-     </widget>
-     <widget class="Element::Text" name="successText">
-      <property name="geometry">
-       <rect>
-        <x>260</x>
-        <y>70</y>
-        <width>71</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Success</string>
-      </property>
-     </widget>
-     <widget class="Element::Text" name="infoText">
-      <property name="geometry">
-       <rect>
-        <x>350</x>
-        <y>70</y>
-        <width>41</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Info</string>
-      </property>
-     </widget>
-     <widget class="Element::Text" name="warningText">
-      <property name="geometry">
-       <rect>
-        <x>410</x>
-        <y>70</y>
-        <width>71</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Warning</string>
-      </property>
-     </widget>
-     <widget class="Element::Text" name="dangerText">
-      <property name="geometry">
-       <rect>
-        <x>500</x>
-        <y>70</y>
-        <width>61</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Danger</string>
-      </property>
-     </widget>
      <widget class="QPlainTextEdit" name="shadow_1">
       <property name="geometry">
        <rect>
-        <x>50</x>
-        <y>540</y>
+        <x>60</x>
+        <y>250</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -139,8 +61,8 @@
      <widget class="QPlainTextEdit" name="shadow_2">
       <property name="geometry">
        <rect>
-        <x>260</x>
-        <y>540</y>
+        <x>270</x>
+        <y>250</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -149,8 +71,8 @@
      <widget class="QPlainTextEdit" name="shadow_3">
       <property name="geometry">
        <rect>
-        <x>470</x>
-        <y>540</y>
+        <x>480</x>
+        <y>250</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -159,8 +81,8 @@
      <widget class="QPlainTextEdit" name="shadow_4">
       <property name="geometry">
        <rect>
-        <x>680</x>
-        <y>540</y>
+        <x>690</x>
+        <y>250</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -179,210 +101,59 @@
        <enum>Qt::Vertical</enum>
       </property>
      </widget>
-     <widget class="QWidget" name="widget" native="true">
+     <widget class="QWidget" name="showText" native="true">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>100</y>
-        <width>1061</width>
-        <height>421</height>
+        <x>90</x>
+        <y>120</y>
+        <width>741</width>
+        <height>61</height>
        </rect>
       </property>
-      <property name="styleSheet">
-       <string notr="true"/>
-      </property>
-      <widget class="QWidget" name="widget_3" native="true">
-       <property name="geometry">
-        <rect>
-         <x>740</x>
-         <y>70</y>
-         <width>271</width>
-         <height>41</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <widget class="QLabel" name="dividerText_6">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>61</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>雨纷纷</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-       <widget class="QLabel" name="dividerText_7">
-        <property name="geometry">
-         <rect>
-          <x>80</x>
-          <y>10</y>
-          <width>61</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>旧故里</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-       <widget class="QLabel" name="dividerText_8">
-        <property name="geometry">
-         <rect>
-          <x>140</x>
-          <y>10</y>
-          <width>61</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>草木深</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </widget>
-      <widget class="QWidget" name="widget_1" native="true">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>10</y>
-         <width>591</width>
-         <height>121</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <widget class="QLabel" name="dividerText_1">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>491</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>青春是一个短暂的美梦, 当你醒来时, 它早已消失无踪</string>
-        </property>
-       </widget>
-       <widget class="QLabel" name="dividerText_2">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>70</y>
-          <width>461</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>少量的邪恶足以抵消全部高贵的品质, 害得人声名狼藉</string>
-        </property>
-       </widget>
-      </widget>
-      <widget class="QWidget" name="widget_2" native="true">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>150</y>
-         <width>641</width>
-         <height>271</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">border-color: rgb(184, 184, 184);</string>
-       </property>
-       <widget class="QLabel" name="dividerText_3">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>381</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>头上一片晴天，心中一个想念</string>
-        </property>
-       </widget>
-       <widget class="QLabel" name="dividerText_4">
-        <property name="geometry">
-         <rect>
-          <x>30</x>
-          <y>80</y>
-          <width>381</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>饿了别叫妈, 叫饿了么</string>
-        </property>
-       </widget>
-       <widget class="QLabel" name="dividerText_5">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>140</y>
-          <width>381</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>为了无法计算的价值</string>
-        </property>
-       </widget>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="Element::Text" name="defaultText">
+         <property name="text">
+          <string>Default</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Element::Text" name="primaryText">
+         <property name="text">
+          <string>Primary</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Element::Text" name="successText">
+         <property name="text">
+          <string>Success</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Element::Text" name="infoText">
+         <property name="text">
+          <string>Info</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Element::Text" name="warningText">
+         <property name="text">
+          <string>Warning</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Element::Text" name="dangerText">
+         <property name="text">
+          <string>Danger</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
     <widget class="QWidget" name="tab_1">
@@ -2584,20 +2355,225 @@
        <rect>
         <x>20</x>
         <y>20</y>
-        <width>600</width>
-        <height>350</height>
+        <width>501</width>
+        <height>261</height>
        </rect>
       </property>
      </widget>
      <widget class="Element::Image" name="image" native="true">
       <property name="geometry">
        <rect>
-        <x>670</x>
+        <x>660</x>
         <y>20</y>
         <width>300</width>
-        <height>300</height>
+        <height>281</height>
        </rect>
       </property>
+     </widget>
+     <widget class="QWidget" name="widget" native="true">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>310</y>
+        <width>1061</width>
+        <height>411</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <widget class="QWidget" name="widget_3" native="true">
+       <property name="geometry">
+        <rect>
+         <x>740</x>
+         <y>70</y>
+         <width>271</width>
+         <height>41</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <widget class="QLabel" name="dividerText_6">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>雨纷纷</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_7">
+        <property name="geometry">
+         <rect>
+          <x>80</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>旧故里</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_8">
+        <property name="geometry">
+         <rect>
+          <x>140</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>草木深</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="widget_1" native="true">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>10</y>
+         <width>591</width>
+         <height>121</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <widget class="QLabel" name="dividerText_1">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>491</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>青春是一个短暂的美梦, 当你醒来时, 它早已消失无踪</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_2">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>70</y>
+          <width>461</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>少量的邪恶足以抵消全部高贵的品质, 害得人声名狼藉</string>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="widget_2" native="true">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>150</y>
+         <width>641</width>
+         <height>271</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">border-color: rgb(184, 184, 184);</string>
+       </property>
+       <widget class="QLabel" name="dividerText_3">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>头上一片晴天，心中一个想念</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_4">
+        <property name="geometry">
+         <rect>
+          <x>30</x>
+          <y>80</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>饿了别叫妈, 叫饿了么</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_5">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>140</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>为了无法计算的价值</string>
+        </property>
+       </widget>
+      </widget>
      </widget>
     </widget>
    </widget>

--- a/example/example.ui
+++ b/example/example.ui
@@ -27,7 +27,7 @@
      <enum>QTabWidget::Rounded</enum>
     </property>
     <property name="currentIndex">
-     <number>0</number>
+     <number>5</number>
     </property>
     <property name="elideMode">
      <enum>Qt::ElideNone</enum>
@@ -1386,6 +1386,19 @@
       </property>
       <property name="text">
        <string>On Close</string>
+      </property>
+     </widget>
+     <widget class="Element::Button" name="pushButton">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>430</y>
+        <width>93</width>
+        <height>28</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Popover</string>
       </property>
      </widget>
     </widget>

--- a/example/example.ui
+++ b/example/example.ui
@@ -27,7 +27,7 @@
      <enum>QTabWidget::Rounded</enum>
     </property>
     <property name="currentIndex">
-     <number>10</number>
+     <number>0</number>
     </property>
     <property name="elideMode">
      <enum>Qt::ElideNone</enum>
@@ -51,8 +51,8 @@
      <widget class="Element::Text" name="defaultText">
       <property name="geometry">
        <rect>
-        <x>60</x>
-        <y>80</y>
+        <x>70</x>
+        <y>70</y>
         <width>65</width>
         <height>21</height>
        </rect>
@@ -64,8 +64,8 @@
      <widget class="Element::Text" name="primaryText">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>88</y>
+        <x>170</x>
+        <y>70</y>
         <width>71</width>
         <height>21</height>
        </rect>
@@ -78,7 +78,7 @@
       <property name="geometry">
        <rect>
         <x>260</x>
-        <y>90</y>
+        <y>70</y>
         <width>71</width>
         <height>21</height>
        </rect>
@@ -91,7 +91,7 @@
       <property name="geometry">
        <rect>
         <x>350</x>
-        <y>90</y>
+        <y>70</y>
         <width>41</width>
         <height>21</height>
        </rect>
@@ -103,8 +103,8 @@
      <widget class="Element::Text" name="warningText">
       <property name="geometry">
        <rect>
-        <x>420</x>
-        <y>90</y>
+        <x>410</x>
+        <y>70</y>
         <width>71</width>
         <height>21</height>
        </rect>
@@ -116,8 +116,8 @@
      <widget class="Element::Text" name="dangerText">
       <property name="geometry">
        <rect>
-        <x>510</x>
-        <y>90</y>
+        <x>500</x>
+        <y>70</y>
         <width>61</width>
         <height>20</height>
        </rect>
@@ -130,7 +130,7 @@
       <property name="geometry">
        <rect>
         <x>50</x>
-        <y>390</y>
+        <y>540</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -140,7 +140,7 @@
       <property name="geometry">
        <rect>
         <x>260</x>
-        <y>390</y>
+        <y>540</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -150,7 +150,7 @@
       <property name="geometry">
        <rect>
         <x>470</x>
-        <y>390</y>
+        <y>540</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -160,7 +160,7 @@
       <property name="geometry">
        <rect>
         <x>680</x>
-        <y>390</y>
+        <y>540</y>
         <width>160</width>
         <height>160</height>
        </rect>
@@ -178,6 +178,211 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
+     </widget>
+     <widget class="QWidget" name="widget" native="true">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>100</y>
+        <width>1061</width>
+        <height>421</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <widget class="QWidget" name="widget_3" native="true">
+       <property name="geometry">
+        <rect>
+         <x>740</x>
+         <y>70</y>
+         <width>271</width>
+         <height>41</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <widget class="QLabel" name="dividerText_6">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>雨纷纷</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_7">
+        <property name="geometry">
+         <rect>
+          <x>80</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>旧故里</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_8">
+        <property name="geometry">
+         <rect>
+          <x>140</x>
+          <y>10</y>
+          <width>61</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>草木深</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="widget_1" native="true">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>10</y>
+         <width>591</width>
+         <height>121</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <widget class="QLabel" name="dividerText_1">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>491</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>青春是一个短暂的美梦, 当你醒来时, 它早已消失无踪</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_2">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>70</y>
+          <width>461</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>少量的邪恶足以抵消全部高贵的品质, 害得人声名狼藉</string>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="widget_2" native="true">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>150</y>
+         <width>641</width>
+         <height>271</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">border-color: rgb(184, 184, 184);</string>
+       </property>
+       <widget class="QLabel" name="dividerText_3">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>头上一片晴天，心中一个想念</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_4">
+        <property name="geometry">
+         <rect>
+          <x>30</x>
+          <y>80</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>饿了别叫妈, 叫饿了么</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="dividerText_5">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>140</y>
+          <width>381</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>为了无法计算的价值</string>
+        </property>
+       </widget>
+      </widget>
      </widget>
     </widget>
     <widget class="QWidget" name="tab_1">
@@ -351,7 +556,7 @@
        <rect>
         <x>20</x>
         <y>310</y>
-        <width>283</width>
+        <width>331</width>
         <height>80</height>
        </rect>
       </property>
@@ -650,8 +855,8 @@
        <rect>
         <x>470</x>
         <y>190</y>
-        <width>72</width>
-        <height>15</height>
+        <width>55</width>
+        <height>19</height>
        </rect>
       </property>
       <property name="text">
@@ -1399,6 +1604,19 @@
        </rect>
       </property>
      </widget>
+     <widget class="Element::Button" name="button_65">
+      <property name="geometry">
+       <rect>
+        <x>710</x>
+        <y>150</y>
+        <width>93</width>
+        <height>28</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>On Close</string>
+      </property>
+     </widget>
     </widget>
     <widget class="QWidget" name="tab_6">
      <attribute name="title">
@@ -2135,7 +2353,7 @@
        <rect>
         <x>50</x>
         <y>230</y>
-        <width>331</width>
+        <width>341</width>
         <height>61</height>
        </rect>
       </property>
@@ -2173,7 +2391,7 @@
         <rect>
          <x>230</x>
          <y>20</y>
-         <width>101</width>
+         <width>111</width>
          <height>21</height>
         </rect>
        </property>

--- a/qt-element-ui.pro
+++ b/qt-element-ui.pro
@@ -13,13 +13,13 @@ HEADERS += \
     $$files($$EXM/*.h) \
     $$files($$SRC/*.h) \
     $$files($$PRI/*.h) \
-    $$files($$GAL/*.h)
+    $$files($$GAL/*.h) \
 
 SOURCES += \
     $$files($$EXM/*.cpp) \
     $$files($$SRC/*.cpp) \
     $$files($$PRI/*.cpp) \
-    $$files($$GAL/*.cpp)
+    $$files($$GAL/*.cpp) \
 
 FORMS += \
     $$files($$EXM/*.ui)


### PR DESCRIPTION
### 一. 实现Divider组件
效果图如下：
<img width="1287" height="842" alt="image" src="https://github.com/user-attachments/assets/178857f8-9877-4ac5-9599-a817ae4c009a" />



---
### 二. 为Message组件添加动态效果，以及添加回调函数、设置自动关闭等功能，现在Message类只负责自身淡入、淡出动画，消息位置及各方位消息队列的排布效果由新增类MessageManager负责  
效果图如下：
![GIF](https://github.com/user-attachments/assets/0da5b4e0-0895-4570-b470-6ac16dc39fb5)

---
### 三. 对Dialog的一些修改

1. 样式修改，去除Qt自带的默认边框，添加默认的关闭按钮，添加遮罩Mask；
2. 扩展到三个信号：accepted, rejected和closed（点击ESC，遮罩或关闭按钮），以便进行对关闭行为的拦截；
3. 实现before-close，用户可以给Dialog指定一个void型函数，会由closed信号触发；
4. 可通过setModal设置模态，带遮罩/非模态，不带遮罩；
5. 为Dialog添加淡入/淡出动画。  

>#### Tips:
>1. 官方的有个modal-penetrable遮罩穿透，可能需要为Mask添加方法；
>2. 官方的可以用transition自定义动画属性，可能得用策略模式吧，比较麻烦就先不实现了，写个默认的淡入/淡出动画占个位。  

效果图如下：
<img width="1281" height="840" alt="dialog" src="https://github.com/user-attachments/assets/27f963c2-8450-423a-8b80-6a51f79b21a1" />
