### PR TITLE
feat(Animation): 添加Animation类；对一些控件的小修改

### DIFF
--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -79,8 +79,8 @@ namespace Element
         _title->setSize(Text::Size::Large);
         _confirm->setType(Button::Type::Primary);
 
-        connect(_cancel, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Rejected, false); });
-        connect(_confirm, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Accepted, false); });
+        connect(_cancel, &QPushButton::clicked, this, [this]() { emit rejected(); });
+        connect(_confirm, &QPushButton::clicked, this, [this]() { emit accepted(); });
 
         if (parentWidget())
             parentWidget()->installEventFilter(this);
@@ -104,6 +104,12 @@ namespace Element
         return *this;
     }
 
+    Dialog& Dialog::setBeforeOpen(const std::function<void(std::function<void()>)>& callback)
+    {
+        _beforeOpenCallback = callback;
+        return *this;
+    }
+
     Dialog& Dialog::setBeforeClose(const std::function<void(std::function<void()>)>& callback)
     {
         _beforeCloseCallback = callback;
@@ -114,13 +120,17 @@ namespace Element
     void Dialog::show()
     {
         QDialog::show();
-        getFocus();
+        Dialog::setFocus();
 
         QWidget* pw = qobject_cast<QWidget*>(parent());
         if (pw && _modal)
         {
-            _mask = MaskEf::setMask(this, pw);
-            connect(_mask, &Mask::clicked, this, [this]() { closeDialog(QDialog::Rejected, true); });
+            if(!_mask)
+            {
+                _mask = MaskEf::setMask(this, pw);
+                connect(_mask, &Mask::clicked, this, [this]() { closeDialog(false); });
+            }
+
             Animation::fadeIn(_mask, Animation::Type::GraphicsEffect, 300);
 
             QEventLoop loop;
@@ -131,40 +141,47 @@ namespace Element
         }
     }
 
-    void Dialog::closeDialog(int result, bool emitClosed)
+    void Dialog::closeDialog(bool expectedClose)
     {
-        if (_beforeCloseCallback && emitClosed)
-        {
-            _beforeCloseCallback([this, result, emitClosed]() {
-                doClose(result, emitClosed);
-            });
-        }
+        if (_beforeCloseCallback && !expectedClose)
+            _beforeCloseCallback([this](){ startClose(); });
         else
-        {
-            doClose(result, emitClosed);
-        }
+            startClose();
     }
 
-    void Dialog::getFocus()
+    void Dialog::setFocus()
     {
         activateWindow();
-        setFocus();
+        QDialog::setFocus();
     }
 
     void Dialog::showEvent(QShowEvent *event)
     {
-        QDialog::showEvent(event);
+        QDialog::showEvent(event);  
 
         if (parentWidget())
             updatePosition();
 
-        Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300);
+        if (_beforeOpenCallback)
+        {
+            _beforeOpenCallback([this]() {
+                Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300, [this](){
+                    emit opened();
+                });
+            });
+        }
+        else
+        {
+            Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300, [this](){
+                emit opened();
+            });
+        }
     }
 
     void Dialog::keyPressEvent(QKeyEvent *event)
     {
         if (event->key() == Qt::Key_Escape)
-            closeDialog(QDialog::Rejected, true);
+            closeDialog(false);
         else
             QDialog::keyPressEvent(event);
     }
@@ -187,26 +204,27 @@ namespace Element
             }
             else if (event->type() == QEvent::MouseButtonPress)
             {
-                closeDialog(QDialog::Rejected, true);
+                closeDialog(false);
             }
         }
         else if (watched == parentWidget())
         {
             if(event->type() == QEvent::Resize || event->type() == QEvent::Move)
+            {
                 updatePosition();
+                return false;
+            }
         }
         return QWidget::eventFilter(watched, event);
     }
 
-    void Dialog::doClose(int result, bool emitClosed)
+    void Dialog::startClose()
     {
         // Prevents multiple simultaneous close attempts.
         if(isClosing)
             return;
 
         isClosing = true;
-
-        setResult(result);
 
         _cancel->setDisabled(true);
         _confirm->setDisabled(true);
@@ -217,13 +235,8 @@ namespace Element
             Animation::fadeOut(_mask, Animation::Type::GraphicsEffect, 300);
         }
 
-        Animation::fadeOutMove(this, Animation::Type::WindowOpacity, -20, 300, [this, result, emitClosed]() {
-            if (result == QDialog::Accepted)
-                emit accepted();
-            else if (emitClosed)
-                emit closed();
-            else
-                emit rejected();
+        Animation::fadeOutMove(this, Animation::Type::WindowOpacity, -20, 300, [this]() {
+            emit closed();
             QDialog::close();
         });
     }

--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -1,6 +1,5 @@
 #include "dialog.h"
-#include "shadow.h"
-#include "mask.h"
+#include "private/animation.h"
 
 #include <QBoxLayout>
 #include <QTimer>
@@ -83,23 +82,8 @@ namespace Element
         connect(_cancel, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Rejected, false); });
         connect(_confirm, &QPushButton::clicked, this, [this]() { closeDialog(QDialog::Accepted, false); });
 
-        setWindowOpacity(0.0);
-
-        _moveAni = new QPropertyAnimation(this, "geometry");
-        _moveAni->setDuration(300);
-        _moveAni->setEasingCurve(QEasingCurve::OutCubic);
-
-        _opaAni = new QPropertyAnimation(this, "windowOpacity");
-        _opaAni->setDuration(300);
-        _opaAni->setStartValue(0.0);
-        _opaAni->setEndValue(1.0);
-        _opaAni->setEasingCurve(QEasingCurve::OutCubic);
-
-        _inAni = new QParallelAnimationGroup(this);
-        _inAni->addAnimation(_moveAni);
-        _inAni->addAnimation(_opaAni);
-
-        _outAni = new QParallelAnimationGroup(this);
+        if (parentWidget())
+            parentWidget()->installEventFilter(this);
     }
 
     Dialog& Dialog::setTitle(const QString &title)
@@ -130,13 +114,14 @@ namespace Element
     void Dialog::show()
     {
         QDialog::show();
-        activateWindow();
-        setFocus();
+        getFocus();
 
         QWidget* pw = qobject_cast<QWidget*>(parent());
-        if (pw && _modal) {
-            Mask* mask = MaskEf::setMask(this, pw);
-            connect(mask, &Mask::clicked, this, [this]() { closeDialog(QDialog::Rejected, true); });
+        if (pw && _modal)
+        {
+            _mask = MaskEf::setMask(this, pw);
+            connect(_mask, &Mask::clicked, this, [this]() { closeDialog(QDialog::Rejected, true); });
+            Animation::fadeIn(_mask, Animation::Type::GraphicsEffect, 300);
 
             QEventLoop loop;
             connect(this, &QDialog::finished, &loop, &QEventLoop::quit);
@@ -160,29 +145,20 @@ namespace Element
         }
     }
 
+    void Dialog::getFocus()
+    {
+        activateWindow();
+        setFocus();
+    }
+
     void Dialog::showEvent(QShowEvent *event)
     {
         QDialog::showEvent(event);
 
         if (parentWidget())
-        {
-            int parentHeight = parentWidget()->height();
-            int targetY = parentWidget()->pos().y() + parentHeight * 0.18;
+            updatePosition();
 
-            move(parentWidget()->pos().x() + (parentWidget()->width() - width()) / 2,
-                 targetY);
-        }
-
-        QRect endRect = geometry();
-        QRect startRect = endRect;
-        startRect.moveTop(endRect.y() - 20);
-        _moveAni->setStartValue(startRect);
-        _moveAni->setEndValue(endRect);
-
-        _opaAni->setStartValue(0.0);
-        _opaAni->setEndValue(1.0);
-
-        _inAni->start();
+        Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300);
     }
 
     void Dialog::keyPressEvent(QKeyEvent *event)
@@ -214,35 +190,34 @@ namespace Element
                 closeDialog(QDialog::Rejected, true);
             }
         }
+        else if (watched == parentWidget())
+        {
+            if(event->type() == QEvent::Resize || event->type() == QEvent::Move)
+                updatePosition();
+        }
         return QWidget::eventFilter(watched, event);
     }
 
     void Dialog::doClose(int result, bool emitClosed)
     {
-        if (_outAni->state() == QAbstractAnimation::Running)
+        // Prevents multiple simultaneous close attempts.
+        if(isClosing)
             return;
+
+        isClosing = true;
 
         setResult(result);
 
         _cancel->setDisabled(true);
         _confirm->setDisabled(true);
+        _close->setDisabled(true);
+        if(_mask && _modal)
+        {
+            _mask->setDisabled(true);
+            Animation::fadeOut(_mask, Animation::Type::GraphicsEffect, 300);
+        }
 
-        _opaAni->setStartValue(windowOpacity());
-        _opaAni->setEndValue(0.0);
-        _opaAni->setDuration(150);
-        _opaAni->setEasingCurve(QEasingCurve::OutCubic);
-        _outAni->clear();
-        _outAni->addAnimation(_opaAni);
-
-        QRect endRect = geometry();
-        endRect.moveTop(endRect.y() - 20);
-        _moveAni->setStartValue(geometry());
-        _moveAni->setEndValue(endRect);
-        _moveAni->setDuration(150);
-        _moveAni->setEasingCurve(QEasingCurve::OutCubic);
-        _outAni->addAnimation(_moveAni);
-
-        connect(_outAni, &QParallelAnimationGroup::finished, this, [this, result, emitClosed]() {
+        Animation::fadeOutMove(this, Animation::Type::WindowOpacity, -20, 300, [this, result, emitClosed]() {
             if (result == QDialog::Accepted)
                 emit accepted();
             else if (emitClosed)
@@ -251,6 +226,16 @@ namespace Element
                 emit rejected();
             QDialog::close();
         });
-        _outAni->start();
+    }
+
+    void Dialog::updatePosition()
+    {
+        if (!parentWidget()) return;
+
+        int parentHeight = parentWidget()->height();
+        int targetY = parentWidget()->pos().y() + parentHeight * 0.18;
+
+        move(parentWidget()->pos().x() + (parentWidget()->width() - width()) / 2,
+             targetY);
     }
 }

--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -104,6 +104,12 @@ namespace Element
         return *this;
     }
 
+    Dialog& Dialog::setDestroyOnClose(bool destroy)
+    {
+        setAttribute(Qt::WA_DeleteOnClose, destroy);
+        return *this;
+    }
+
     Dialog& Dialog::setBeforeOpen(const std::function<void(std::function<void()>)>& callback)
     {
         _beforeOpenCallback = callback;

--- a/components/dialog.h
+++ b/components/dialog.h
@@ -2,10 +2,9 @@
 
 #include "text.h"
 #include "button.h"
+#include "mask.h"
 
 #include <QDialog>
-#include <QPropertyAnimation>
-#include <QParallelAnimationGroup>
 
 namespace Element
 {
@@ -26,6 +25,7 @@ namespace Element
 
         void show();
         void closeDialog(int result, bool emitClosed);
+        void getFocus();
 
     public:
         Dialog(QWidget* parent = nullptr);
@@ -38,20 +38,17 @@ namespace Element
 
     private:
         void doClose(int result, bool emitClosed);
+        void updatePosition();
 
     private:
         bool _modal = true;
+        bool isClosing = false;
+        Mask* _mask = nullptr;
         Text* _title;
         Text* _content;
         Button* _cancel;
         Button* _confirm;
         std::function<void(std::function<void()>)> _beforeCloseCallback;
-
-    private:
         QLabel* _close;
-        QPropertyAnimation* _opaAni;
-        QPropertyAnimation* _moveAni;
-        QParallelAnimationGroup* _inAni;
-        QParallelAnimationGroup* _outAni;
     };
 }

--- a/components/dialog.h
+++ b/components/dialog.h
@@ -13,19 +13,21 @@ namespace Element
     Q_OBJECT
 
     signals:
+        void opened();
         void accepted();
         void rejected();
-        void closed();  // Click ESC, mask or close button.
+        void closed();
 
     public:
         Dialog& setTitle(const QString& title);
         Dialog& setContent(const QString& content);
         Dialog& setModal(bool modal);
+        Dialog& setBeforeOpen(const std::function<void(std::function<void()>)>& callback);
         Dialog& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
 
         void show();
-        void closeDialog(int result, bool emitClosed);
-        void getFocus();
+        void closeDialog(bool expectedClose = true);
+        void setFocus();
 
     public:
         Dialog(QWidget* parent = nullptr);
@@ -37,7 +39,7 @@ namespace Element
         bool eventFilter(QObject* watched, QEvent* event) override;
 
     private:
-        void doClose(int result, bool emitClosed);
+        void startClose();
         void updatePosition();
 
     private:
@@ -48,7 +50,8 @@ namespace Element
         Text* _content;
         Button* _cancel;
         Button* _confirm;
-        std::function<void(std::function<void()>)> _beforeCloseCallback;
         QLabel* _close;
+        std::function<void(std::function<void()>)> _beforeOpenCallback;
+        std::function<void(std::function<void()>)> _beforeCloseCallback;
     };
 }

--- a/components/dialog.h
+++ b/components/dialog.h
@@ -22,6 +22,7 @@ namespace Element
         Dialog& setTitle(const QString& title);
         Dialog& setContent(const QString& content);
         Dialog& setModal(bool modal);
+        Dialog& setDestroyOnClose(bool destroy);
         Dialog& setBeforeOpen(const std::function<void(std::function<void()>)>& callback);
         Dialog& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
 

--- a/components/drawer.cpp
+++ b/components/drawer.cpp
@@ -16,6 +16,7 @@ namespace Element
         : QWidget(topWidget)
         , _layout(new QVBoxLayout(this))
     {
+        setAttribute(Qt::WA_DeleteOnClose);
         setupHeader();
         setupBody();
         setupFooter();
@@ -40,6 +41,12 @@ namespace Element
     {
         _bodyLayout->replaceWidget(_body, body);
         _body = body;
+        return *this;
+    }
+
+    Drawer& Drawer::setDestroyOnClose(bool destroy)
+    {
+        setAttribute(Qt::WA_DeleteOnClose, destroy);
         return *this;
     }
 

--- a/components/drawer.cpp
+++ b/components/drawer.cpp
@@ -3,8 +3,8 @@
 #include "icon.h"
 #include "color.h"
 #include "private/utils.h"
+#include "private/animation.h"
 #include "shadow.h"
-#include "mask.h"
 
 #include <QtMath>
 #include <QEvent>
@@ -25,18 +25,33 @@ namespace Element
         _layout->addStretch();
         _layout->addWidget(_footer);
 
+        ShadowEf::setShadow(this, ShadowEf::Type::Dark);
+        _mask = MaskEf::setMask(this, parentWidget());
+        connect(_mask, &Mask::clicked, this, [this](){closeDrawer(false);});
+
         setVisible(false);
 
-        ShadowEf::setShadow(this, ShadowEf::Type::Dark);
-        Mask* mask = MaskEf::setMask(this, topWidget);
+        updatePosition();
 
-        connect(mask, &Mask::clicked, this, &Drawer::hide);
+        topWidget->installEventFilter(this);
     }
 
     Drawer& Drawer::setBody(QWidget* body)
     {
         _bodyLayout->replaceWidget(_body, body);
         _body = body;
+        return *this;
+    }
+
+    Drawer& Drawer::setBeforeOpen(const std::function<void(std::function<void()>)>& callback)
+    {
+        _beforeOpenCallback = callback;
+        return *this;
+    }
+
+    Drawer& Drawer::setBeforeClose(const std::function<void(std::function<void()>)>& callback)
+    {
+        _beforeCloseCallback = callback;
         return *this;
     }
 
@@ -55,7 +70,7 @@ namespace Element
         _closeIcon->setAttribute(Qt::WA_Hover);
         _closeIcon->installEventFilter(this);
         _closeIcon->setPixmap(Icon::instance().getPixmap(Icon::Close, Color::primaryText(), 20));
-        connect(_closeIcon, &QLabel::linkActivated, this, &Drawer::close);
+        connect(_closeIcon, &QLabel::linkActivated, this, [this](){closeDrawer(false);});
 
         QHBoxLayout* layout = new QHBoxLayout(_header);
         layout->setContentsMargins(20, 20, 20, 20);
@@ -88,20 +103,161 @@ namespace Element
         layout->addWidget(_cancelBtn);
         layout->addWidget(_confirmBtn);
 
-        connect(_cancelBtn, &Button::clicked, this, &Drawer::close);
-        connect(_confirmBtn, &Button::clicked, this, &Drawer::confirm);
+        connect(_cancelBtn, &Button::clicked, this, [this]() {emit rejected();});
+        connect(_confirmBtn, &Button::clicked, this, [this]() {emit accepted();});
     }
 
-    void Drawer::resizeEvent(QResizeEvent* event)
+    void Drawer::updatePosition()
     {
         QWidget* topWidget = parentWidget();
-        QRect rect = topWidget->rect();
 
-        rect.setLeft(qRound(topWidget->rect().width() * 0.7));
-        rect.setWidth(qRound(topWidget->rect().width() * 0.3));
-        setGeometry(rect);
+        QRect parentRect = topWidget->rect();
+        int parentWidth = parentRect.width();
+        int parentHeight = parentRect.height();
 
-        QWidget::resizeEvent(event);
+        QRect targetRect;
+        switch (_direction)
+        {
+        case Direction::LeftToRight:
+            targetRect.setRect(0, 0, parentWidth * 0.3, parentHeight);
+            break;
+        case Direction::RightToLeft:
+            targetRect.setRect(parentWidth * 0.7, 0, parentWidth * 0.3, parentHeight);
+            break;
+        case Direction::TopToBottom:
+            targetRect.setRect(0, 0, parentWidth, parentHeight * 0.3);
+            break;
+        case Direction::BottomToTop:
+            targetRect.setRect(0, parentHeight * 0.7, parentWidth, parentHeight * 0.3);
+            break;
+        }
+
+        if (isVisible())
+        {
+            setGeometry(targetRect);
+        }
+        else
+        {
+            QRect slideOutRect;
+            switch (_direction)
+            {
+            case Direction::LeftToRight:
+                slideOutRect = QRect(-targetRect.width(), targetRect.y(), targetRect.width(), targetRect.height());
+                break;
+            case Direction::RightToLeft:
+                slideOutRect = QRect(parentWidth, targetRect.y(), targetRect.width(), targetRect.height());
+                break;
+            case Direction::TopToBottom:
+                slideOutRect = QRect(targetRect.x(), -targetRect.height(), targetRect.width(), targetRect.height());
+                break;
+            case Direction::BottomToTop:
+                slideOutRect = QRect(targetRect.x(), parentHeight, targetRect.width(), targetRect.height());
+                break;
+            }
+            setGeometry(slideOutRect);
+        }
+    }
+
+    void Drawer::startOpen()
+    {
+        if(_modal)
+        {
+            _mask->setDisabled(true);
+            Animation::fadeIn(_mask, Animation::Type::GraphicsEffect, 300, [this](){
+                _mask->setDisabled(false);
+            });
+        }
+        else
+        {
+            _mask->hide();
+        }
+
+        Animation::move(this, getSlideInPosition(), 300, [this](){
+            emit opened();
+        });
+    }
+
+    void Drawer::startClose()
+    {
+        _isClosing = true;
+
+        if(_modal)
+        {
+            _mask->setDisabled(true);
+            Animation::fadeOut(_mask, Animation::Type::GraphicsEffect, 300, [this](){
+                _mask->setDisabled(false);
+            });
+        }
+        else
+        {
+            _mask->hide();
+        }
+
+        Animation::move(this, getSlideOutPosition(), 300, [this](){
+            QWidget::hide();
+            _isClosing = false;
+            emit closed();
+        });
+    }
+
+    void Drawer::closeDrawer(bool expectedClose)
+    {
+        if (_beforeCloseCallback && !expectedClose)
+            _beforeCloseCallback([this](){ startClose(); });
+        else
+            startClose();
+    }
+
+    QRect Drawer::getSlideInPosition()
+    {
+        QRect currentRect = geometry();
+        QRect slideInStart;
+        switch (_direction)
+        {
+        case Direction::LeftToRight:
+            slideInStart = QRect(currentRect.x() + currentRect.width(), currentRect.y(),
+                                   currentRect.width(), currentRect.height());
+            break;
+        case Direction::RightToLeft:
+            slideInStart = QRect(currentRect.x() - currentRect.width(), currentRect.y(),
+                                   currentRect.width(), currentRect.height());
+            break;
+        case Direction::TopToBottom:
+            slideInStart = QRect(currentRect.x(), currentRect.y() + currentRect.height(),
+                                   currentRect.width(), currentRect.height());
+            break;
+        case Direction::BottomToTop:
+            slideInStart = QRect(currentRect.x(), currentRect.y() - currentRect.height(),
+                                   currentRect.width(), currentRect.height());
+            break;
+        }
+        return slideInStart;
+    }
+
+    QRect Drawer::getSlideOutPosition()
+    {
+        QRect currentRect = geometry();
+        QRect slideOutTarget;
+        switch (_direction)
+        {
+        case Direction::LeftToRight:
+            slideOutTarget = QRect(currentRect.x() - currentRect.width(), currentRect.y(),
+                                 currentRect.width(), currentRect.height());
+            break;
+        case Direction::RightToLeft:
+            slideOutTarget = QRect(currentRect.x() + currentRect.width(), currentRect.y(),
+                                 currentRect.width(), currentRect.height());
+            break;
+        case Direction::TopToBottom:
+            slideOutTarget = QRect(currentRect.x(), currentRect.y() - currentRect.height(),
+                                 currentRect.width(), currentRect.height());
+            break;
+        case Direction::BottomToTop:
+            slideOutTarget = QRect(currentRect.x(), currentRect.y() + currentRect.height(),
+                                 currentRect.width(), currentRect.height());
+            break;
+        }
+        return slideOutTarget;
     }
 
     bool Drawer::eventFilter(QObject* watched, QEvent* event)
@@ -125,6 +281,36 @@ namespace Element
                 emit _closeIcon->linkActivated("");
             }
         }
+        else if (watched == parentWidget())
+        {
+            if(event->type() == QEvent::Resize || event->type() == QEvent::Move)
+            {
+                updatePosition();
+                return false;
+            }
+        }
         return QWidget::eventFilter(watched, event);
+    }
+
+    void Drawer::showEvent(QShowEvent* event)
+    {
+        if(_isClosing) return;
+
+        QWidget::showEvent(event);
+
+        setFocus();
+
+        if (_beforeOpenCallback)
+            _beforeOpenCallback([this](){ startOpen(); });
+        else
+            startOpen();
+    }
+
+    void Drawer::keyPressEvent(QKeyEvent *event)
+    {
+        if (event->key() == Qt::Key_Escape)
+            closeDrawer(false);
+        else
+            QWidget::keyPressEvent(event);
     }
 }

--- a/components/drawer.cpp
+++ b/components/drawer.cpp
@@ -127,7 +127,4 @@ namespace Element
         }
         return QWidget::eventFilter(watched, event);
     }
-
-
-
 }

--- a/components/drawer.h
+++ b/components/drawer.h
@@ -37,6 +37,7 @@ namespace Element
         Drawer& setWithHeader(bool withHeader);
         Drawer& setWithFooter(bool withFooter);
         Drawer& setBody(QWidget* body);
+        Drawer& setDestroyOnClose(bool destroy);
         Drawer& setBeforeOpen(const std::function<void(std::function<void()>)>& callback);
         Drawer& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
 

--- a/components/drawer.h
+++ b/components/drawer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "button.h"
+#include "mask.h"
 
 #include <QWidget>
 #include <QLabel>
@@ -21,6 +22,12 @@ namespace Element
             BottomToTop,
         };
 
+    signals:
+        void opened();
+        void accepted();
+        void rejected();
+        void closed();
+
     public:
         Drawer& setModal(bool modal);
         Drawer& setDirection(Direction direction);
@@ -30,30 +37,40 @@ namespace Element
         Drawer& setWithHeader(bool withHeader);
         Drawer& setWithFooter(bool withFooter);
         Drawer& setBody(QWidget* body);
+        Drawer& setBeforeOpen(const std::function<void(std::function<void()>)>& callback);
+        Drawer& setBeforeClose(const std::function<void(std::function<void()>)>& callback);
 
-    signals:
-        void confirm();
+        void closeDrawer(bool expectedClose = true);
 
     public:
         Drawer(QWidget* topWidget);
 
     protected:
-        void resizeEvent(QResizeEvent* event) override;
         bool eventFilter(QObject* watched, QEvent* event) override;
+        void showEvent(QShowEvent* event) override;
+        void keyPressEvent(QKeyEvent *event) override;
 
     private:
         void setupHeader();
         void setupBody();
         void setupFooter();
+        void updatePosition();
+        void startOpen();
+        void startClose();
+        QRect getSlideInPosition();
+        QRect getSlideOutPosition();
 
     private:
-        bool _modal = false;
+        bool _modal = true;
         Direction _direction = Direction::RightToLeft;
         bool _showClose = true;
         int _percent = 30;
         QString _title = "I am the title";
         bool _withHeader = true;
         bool _withFooter = true;
+        bool _isClosing = false;
+        std::function<void(std::function<void()>)> _beforeOpenCallback;
+        std::function<void(std::function<void()>)> _beforeCloseCallback;
 
     private:
         QWidget* _header = nullptr;
@@ -66,6 +83,7 @@ namespace Element
         QLabel* _closeIcon = nullptr;
         Button* _cancelBtn = nullptr;
         Button* _confirmBtn = nullptr;
+        Mask* _mask = nullptr;
     };
 
 }

--- a/components/drawer.h
+++ b/components/drawer.h
@@ -10,7 +10,7 @@ namespace Element
 {
     class Drawer : public QWidget
     {
-    Q_OBJECT
+        Q_OBJECT
 
     public:
         enum class Direction

--- a/components/mask.cpp
+++ b/components/mask.cpp
@@ -19,6 +19,7 @@ namespace Element
         setGeometry(covered->rect());
         setVisible(partner->isVisible());
         partner->installEventFilter(this);
+        covered->installEventFilter(this);
     }
 
     bool Mask::eventFilter(QObject* watched, QEvent* event)

--- a/components/message.cpp
+++ b/components/message.cpp
@@ -1,7 +1,9 @@
 #include "message.h"
 #include "messagemanager.h"
 #include "private/utils.h"
+#include "private/animation.h"
 #include "icon.h"
+#include "color.h"
 
 #include <QBoxLayout>
 #include <QPainter>
@@ -60,25 +62,6 @@ namespace Element
 
             setType(_type);
             connect(_timer, &QTimer::timeout, this, &Message::onTimeout);
-
-            _opaEff = new QGraphicsOpacityEffect(this);
-            _opaEff->setOpacity(0.0);
-            setGraphicsEffect(_opaEff);
-
-            _moveAni = new QPropertyAnimation(this, "geometry");
-            _moveAni->setDuration(300);
-            _moveAni->setEasingCurve(QEasingCurve::OutCubic);
-
-            _opaAni = new QPropertyAnimation(_opaEff, "opacity");
-            _opaAni->setDuration(300);
-            _opaAni->setStartValue(0.0);
-            _opaAni->setEndValue(1.0);
-            _moveAni->setEasingCurve(QEasingCurve::OutCubic);
-
-            _fadeIn = new QParallelAnimationGroup(this);
-            _fadeIn->addAnimation(_moveAni);
-
-            _fadeOut = new QParallelAnimationGroup(this);
         }
 
     void Message::show()
@@ -174,30 +157,26 @@ namespace Element
 
     void Message::updatePosition()
     {
-        QRect endRect = geometry();
-        QRect startRect = endRect;
+        int offset = 0;
 
         switch (_placement)
         {
         case Place::Top:
         case Place::TopLeft:
         case Place::TopRight:
-            startRect.moveTop(endRect.y() - 20);
+            offset = -(this->geometry().height());
             break;
 
         case Place::Bottom:
         case Place::BottomLeft:
         case Place::BottomRight:
-            startRect.moveTop(endRect.y() + 20);
+            offset = this->geometry().height();
             break;
         }
 
-        _fadeIn->addAnimation(_opaAni);
-        _moveAni->setStartValue(startRect);
-        _moveAni->setEndValue(endRect);
-
         QWidget::show();
-        _fadeIn->start();
+
+        _fadeInAnim = Animation::fadeInMove(this, Animation::Type::GraphicsEffect, offset, 300);
     }
 
     QString Message::getColor()
@@ -259,42 +238,29 @@ namespace Element
 
     void Message::onTimeout()
     {
-        _opaAni->setStartValue(1.0);
-        _opaAni->setEndValue(0.0);
-        _fadeOut->addAnimation(_opaAni);
-
-        QRect gm = geometry();
-        QRect endRect;
+        int offset = 0;
 
         switch(_placement)
         {
         case Place::Top:
         case Place::TopLeft:
         case Place::TopRight:
-            endRect = QRect(gm.x(), gm.y() - 20,
-                            gm.width(), gm.height());
+            offset = -(this->geometry().height());
             break;
 
         case Place::Bottom:
         case Place::BottomLeft:
         case Place::BottomRight:
-            endRect = QRect(gm.x(), gm.y() + 20,
-                            gm.width(), gm.height());
+            offset = this->geometry().height();
             break;
         }
 
-        _moveAni->setStartValue(gm);
-        _moveAni->setEndValue(endRect);
-        _fadeOut->addAnimation(_moveAni);
-
-        connect(_fadeOut, &QParallelAnimationGroup::finished, this, [this]() {
+        Animation::fadeOutMove(this, Animation::Type::GraphicsEffect, offset, 300, [this]() {
             if(_onClose)
                 emit close();
 
             this->deleteLater();
         });
-
-        _fadeOut->start();
 
         if (_manager)
             _manager->removeMessage(this);
@@ -322,10 +288,16 @@ namespace Element
 
     void Message::stopFadeIn()
     {
-        if (_fadeIn->state() == QAbstractAnimation::Running)
-            _fadeIn->stop();
+        if (_fadeInAnim)
+        {
+            _fadeInAnim->stop();
 
-        _opaEff->setOpacity(1.0);
+            if (auto effect = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect()))
+                effect->setOpacity(1.0);
+
+            _fadeInAnim->deleteLater();
+            _fadeInAnim = nullptr;
+        }
     }
 
     bool Message::eventFilter(QObject* watched, QEvent* event)

--- a/components/message.h
+++ b/components/message.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "private/utils.h"
-#include "color.h"
 
 #include <QString>
 #include <QLabel>
 #include <QHash>
 #include <QPoint>
+#include <QPointer>
 #include <QPropertyAnimation>
 #include <QGraphicsOpacityEffect>
 #include <QParallelAnimationGroup>
@@ -99,11 +99,7 @@ namespace Element
         QLabel* _text;
         QLabel* _close;
         QTimer* _timer;
-        QPropertyAnimation* _opaAni;
-        QPropertyAnimation* _moveAni;
-        QGraphicsOpacityEffect* _opaEff;
-        QParallelAnimationGroup* _fadeIn;
-        QParallelAnimationGroup* _fadeOut;
+        QPointer<QParallelAnimationGroup> _fadeInAnim;
 
         MessageManager* _manager; 
         static QHash<QWidget*, MessageManager*> _managersHash;

--- a/components/messagemanager.cpp
+++ b/components/messagemanager.cpp
@@ -1,4 +1,5 @@
 #include "messagemanager.h"
+#include "private/animation.h"
 
 namespace Element
 {
@@ -96,12 +97,12 @@ namespace Element
             if (topAligned)
             {
                 y = curY;
-                curY += h + 10;
+                curY += h + 16;
             }
             else
             {
                 y = curY - h;
-                curY -= (h + 10);
+                curY -= (h + 16);
             }
 
             QRect newRect(x, y, w, h);
@@ -109,12 +110,7 @@ namespace Element
             if (oldRect != newRect)
             {
                 msg->stopFadeIn();
-                QPropertyAnimation* anim = new QPropertyAnimation(msg, "geometry");
-                anim->setDuration(300);
-                anim->setEasingCurve(QEasingCurve::OutCubic);
-                anim->setStartValue(oldRect);
-                anim->setEndValue(newRect);
-                anim->start(QAbstractAnimation::DeleteWhenStopped);
+                Animation::move(msg, newRect);
             }
         }
     }
@@ -157,7 +153,7 @@ namespace Element
         if (topAligned)
         {
             for (int i = 0; i < index; ++i)
-                yOffset += list[i]->height() + 10;
+                yOffset += list[i]->height() + 16;
 
             y = yOffset;
         }
@@ -165,9 +161,9 @@ namespace Element
         {
             int totalHeight = 0;
             for (int i = 0; i <= index; ++i)
-                totalHeight += list[i]->height() + 10;
+                totalHeight += list[i]->height() + 16;
 
-            totalHeight -= 10;
+            totalHeight -= 16;
             y = pw->height() - _offset - totalHeight;
         }
 

--- a/components/private/animation.cpp
+++ b/components/private/animation.cpp
@@ -1,0 +1,148 @@
+#include "animation.h"
+
+#include <QGraphicsOpacityEffect>
+
+namespace Element
+{
+    static QEasingCurve getEasingCurve()
+    {
+        QEasingCurve curve;
+        curve.setType(QEasingCurve::BezierSpline);
+        curve.addCubicBezierSegment(QPointF(0.55, 0.0), QPointF(0.1, 1.0), QPointF(1.0, 1.0));
+        return curve;
+    }
+
+    QPropertyAnimation* Animation::fadeIn(QWidget* widget, Type type, int duration,
+                           std::function<void()> onFinished)
+    {
+        return fade(widget, {0.0, 1.0}, type, duration, onFinished);
+    }
+
+    QPropertyAnimation* Animation::fadeOut(QWidget* widget, Type type, int duration,
+                            std::function<void()> onFinished)
+    {
+        return fade(widget, {1.0, 0.0}, type, duration, onFinished);
+    }
+
+    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, Type type,
+                                  int offset, int duration, std::function<void()> onFinished)
+    {
+        QRect curRect = widget->geometry();
+        QRect startRect = curRect;
+        startRect.moveTop(curRect.y() + offset);
+        return fadeMove(widget, {startRect, widget->geometry()}, {0.0, 1.0}, type, duration, onFinished);
+    }
+
+    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, Type type,
+                              QRect startRect, int duration, std::function<void()> onFinished)
+    {
+        return fadeMove(widget, {startRect, widget->geometry()}, {0.0, 1.0}, type, duration, onFinished);
+    }
+
+    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, Type type,
+                                   int offset, int duration, std::function<void()> onFinished)
+    {
+        QRect curRect = widget->geometry();
+        QRect endRect = curRect;
+        endRect.moveTop(curRect.y() + offset);
+        return fadeMove(widget, {widget->geometry(), endRect}, {1.0, 0.0}, type, duration, onFinished);
+    }
+
+    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, Type type,
+                        QRect endRect, int duration, std::function<void()> onFinished)
+    {
+        return fadeMove(widget, {widget->geometry(), endRect}, {1.0, 0.0}, type, duration, onFinished);
+    }
+
+    QPropertyAnimation* Animation::fade(QWidget* widget, OpacityRange opacity,Type type,
+                         int duration, std::function<void()> onFinished)
+    {
+        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, opacity.first, opacity.second, duration);
+
+        if (onFinished)
+        {
+            QObject::connect(opaAnim, &QPropertyAnimation::finished, onFinished);
+        }
+
+        QObject::connect(opaAnim, &QPropertyAnimation::finished, opaAnim, &QObject::deleteLater);
+        opaAnim->start();
+        return opaAnim;
+    }
+
+    QPropertyAnimation* Animation::move(QWidget* widget, const QRect& targetRect, int duration,
+              std::function<void()> onFinished)
+    {
+        QPropertyAnimation* anim = new QPropertyAnimation(widget, "geometry");
+        anim->setDuration(duration);
+        anim->setEasingCurve(easingCurve());
+        anim->setStartValue(widget->geometry());
+        anim->setEndValue(targetRect);
+
+        if (onFinished)
+        {
+            QObject::connect(anim, &QPropertyAnimation::finished, onFinished);
+        }
+        QObject::connect(anim, &QPropertyAnimation::finished, anim, &QObject::deleteLater);
+        anim->start();
+        return anim;
+    }
+
+    QParallelAnimationGroup* Animation::fadeMove(QWidget* widget, RectRange geometry, OpacityRange opacity,
+                         Type type, int duration, std::function<void()> onFinished)
+    {
+        QParallelAnimationGroup* group = new QParallelAnimationGroup;
+        QPropertyAnimation* moveAnim = new QPropertyAnimation(widget, "geometry");
+        moveAnim->setDuration(duration);
+        moveAnim->setEasingCurve(easingCurve());
+        moveAnim->setStartValue(geometry.first);
+        moveAnim->setEndValue(geometry.second);
+        group->addAnimation(moveAnim);
+
+        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, opacity.first, opacity.second, duration);
+        group->addAnimation(opaAnim);
+
+        if (onFinished)
+        {
+            QObject::connect(group, &QParallelAnimationGroup::finished, onFinished);
+        }
+        QObject::connect(group, &QParallelAnimationGroup::finished, group, &QObject::deleteLater);
+        group->start();
+        return group;
+    }
+
+    const QEasingCurve& Animation::easingCurve()
+    {
+        static const QEasingCurve curve = getEasingCurve();
+        return curve;
+    }
+
+    QPropertyAnimation* Animation::getOpaAnim(QWidget* widget, Element::Animation::Type type,
+                                              double startVal, double endVal, int duration)
+    {
+        QPropertyAnimation* anim = nullptr;
+        if (type == Element::Animation::Type::WindowOpacity)
+        {
+            widget->setWindowOpacity(startVal);
+            anim = new QPropertyAnimation(widget, "windowOpacity");
+        }
+        else
+        {
+            QGraphicsOpacityEffect* effect = qobject_cast<QGraphicsOpacityEffect*>(widget->graphicsEffect());
+            if (!effect)
+            {
+                effect = new QGraphicsOpacityEffect(widget);
+                widget->setGraphicsEffect(effect);
+            }
+            effect->setOpacity(startVal);
+            anim = new QPropertyAnimation(effect, "opacity");
+        }
+        if(anim)
+        {
+            anim->setStartValue(startVal);
+            anim->setEndValue(endVal);
+            anim->setDuration(duration);
+            anim->setEasingCurve(easingCurve());
+        }
+        return anim;
+    }
+}

--- a/components/private/animation.cpp
+++ b/components/private/animation.cpp
@@ -1,6 +1,7 @@
 #include "animation.h"
 
 #include <QGraphicsOpacityEffect>
+#include <QLayout>
 
 namespace Element
 {
@@ -10,6 +11,47 @@ namespace Element
         curve.setType(QEasingCurve::BezierSpline);
         curve.addCubicBezierSegment(QPointF(0.55, 0.0), QPointF(0.1, 1.0), QPointF(1.0, 1.0));
         return curve;
+    }
+
+    QParallelAnimationGroup* Animation::horShrinkFadeOut(QWidget* widget, Type type,
+                                        int duration, std::function<void()> onFinished)
+    {
+        const auto allChildren = widget->findChildren<QWidget*>();
+
+        for (QWidget* child : allChildren)
+        {
+            child->setMinimumWidth(0);
+            QSizePolicy policy = child->sizePolicy();
+            policy.setHorizontalPolicy(QSizePolicy::Ignored);
+            child->setSizePolicy(policy);
+        }
+
+        widget->setMinimumWidth(0);
+        QSizePolicy policy = widget->sizePolicy();
+        policy.setHorizontalPolicy(QSizePolicy::Ignored);
+        widget->setSizePolicy(policy);
+
+        QParallelAnimationGroup* group = new QParallelAnimationGroup;
+        group->addAnimation(getOpaAnim(widget, type, 1.0, 0.0, duration));
+
+        QRect startRect = widget->geometry();
+        int centerX = startRect.x() + startRect.width() / 2;
+        QRect endRect(centerX, startRect.y(), 0, startRect.height());
+
+        QPropertyAnimation* shrAnim = new QPropertyAnimation(widget, "geometry");
+        shrAnim->setDuration(duration);
+        shrAnim->setStartValue(startRect);
+        shrAnim->setEndValue(endRect);
+        shrAnim->setEasingCurve(easingCurve());
+        group->addAnimation(shrAnim);
+
+        if (onFinished)
+        {
+            QObject::connect(group, &QPropertyAnimation::finished, onFinished);
+        }
+        QObject::connect(group, &QPropertyAnimation::finished, group, &QObject::deleteLater);
+        group->start();
+        return group;
     }
 
     QPropertyAnimation* Animation::fadeIn(QWidget* widget, Type type, int duration,

--- a/components/private/animation.h
+++ b/components/private/animation.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QWidget>
+#include <functional>
+#include <QPropertyAnimation>
+#include <QParallelAnimationGroup>
+
+namespace Element
+{
+
+    class Animation
+    {
+    public:
+        // pair<Start_Value, End_Value>
+        using RectRange = std::pair<QRect, QRect>;
+        using OpacityRange = std::pair<double, double>;
+
+        enum class Type {   WindowOpacity, GraphicsEffect  };
+
+        static QPropertyAnimation* fadeIn(QWidget* widget, Type type, int duration = 300,
+                           std::function<void()> onFinished = nullptr);
+
+        static QPropertyAnimation* fadeOut(QWidget* widget, Type type, int duration = 300,
+                            std::function<void()> onFinished = nullptr);
+
+        // The default transition direction is top‑down.
+        static QParallelAnimationGroup* fadeInMove(QWidget* widget, Type type,
+                                  int offset = 20, int duration = 300,
+                                  std::function<void()> onFinished = nullptr);
+
+        static QParallelAnimationGroup* fadeInMove(QWidget* widget, Type type,
+                                  QRect startRect, int duration = 300,
+                                  std::function<void()> onFinished = nullptr);
+
+        // The default transition direction is down-top.
+        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, Type type,
+                                   int offset = 20, int duration = 300,
+                                   std::function<void()> onFinished = nullptr);
+
+        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, Type type,
+                                   QRect endRect, int duration = 300,
+                                   std::function<void()> onFinished = nullptr);
+
+        static QPropertyAnimation* fade(QWidget* widget, OpacityRange opacity,
+                         Type type, int duration,
+                         std::function<void()> onFinished = nullptr);
+
+        static QPropertyAnimation* move(QWidget* widget, const QRect& targetRect, int duration = 300,
+                         std::function<void()> onFinished = nullptr);
+
+        static QParallelAnimationGroup* fadeMove(QWidget* widget, RectRange geometry,
+                             OpacityRange opacity, Type type,
+                             int duration, std::function<void()> onFinished = nullptr);
+
+    private:
+        static const QEasingCurve& easingCurve();
+
+        static QPropertyAnimation* getOpaAnim(QWidget* widget, Element::Animation::Type type, double startVal, double endVal, int duration);
+    };
+}

--- a/components/private/animation.h
+++ b/components/private/animation.h
@@ -17,6 +17,9 @@ namespace Element
 
         enum class Type {   WindowOpacity, GraphicsEffect  };
 
+        static QParallelAnimationGroup* horShrinkFadeOut(QWidget* widget, Type type, int duration = 200,
+                                          std::function<void()> onFinished = nullptr);
+
         static QPropertyAnimation* fadeIn(QWidget* widget, Type type, int duration = 300,
                            std::function<void()> onFinished = nullptr);
 

--- a/components/tag.cpp
+++ b/components/tag.cpp
@@ -3,6 +3,7 @@
 #include "color.h"
 #include "icon.h"
 #include "private/utils.h"
+#include "private/animation.h"
 
 #include <QEvent>
 
@@ -23,6 +24,8 @@ namespace Element
         , _closeIcon(new QLabel(this))
         , _layout(new QHBoxLayout(this))
     {
+        _disTrans = false;
+
         _textLabel->setFont(FontHelper(_textLabel->font())
                 .setPointSize(9)
                 .getFont());
@@ -31,6 +34,7 @@ namespace Element
         _closeIcon->setFixedSize(16, 16);
         _closeIcon->setScaledContents(true);
         _closeIcon->setVisible(false);
+        _closeIcon->setCursor(Qt::PointingHandCursor);
         _closeIcon->installEventFilter(this);
 
         _layout->setContentsMargins(0, 0, 0, 0);
@@ -102,6 +106,12 @@ namespace Element
         return *this;
     }
 
+    Tag& Tag::disableTransitions(bool distrans)
+    {
+        _disTrans = distrans;
+        return *this;
+    }
+
     Tag& Tag::setText(const QString& text)
     {
         _textLabel->setText(text);
@@ -114,7 +124,16 @@ namespace Element
         {
             if (event->type() == QEvent::MouseButtonPress)
             {
-                deleteLater();
+                if(!_disTrans)
+                {
+                    Animation::horShrinkFadeOut(this, Animation::Type::GraphicsEffect, 300, [this](){
+                        this->deleteLater();
+                    });
+                }
+                else
+                {
+                    this->deleteLater();
+                }
                 return true;
             }
             else if (event->type() == QEvent::Enter)

--- a/components/tag.cpp
+++ b/components/tag.cpp
@@ -106,7 +106,7 @@ namespace Element
         return *this;
     }
 
-    Tag& Tag::disableTransitions(bool distrans)
+    Tag& Tag::setDisableTransitions(bool distrans)
     {
         _disTrans = distrans;
         return *this;

--- a/components/tag.h
+++ b/components/tag.h
@@ -42,6 +42,7 @@ namespace Element
 
         Tag& setCloseable(bool closeable);
         Tag& setRound(bool round);
+        Tag& disableTransitions(bool distrans);
 
         Tag& setText(const QString& text);
 
@@ -64,6 +65,7 @@ namespace Element
 
         bool _closeable;
         bool _round;
+        bool _disTrans;
 
         QLabel* _textLabel = nullptr;
         QLabel* _closeIcon = nullptr;

--- a/components/tag.h
+++ b/components/tag.h
@@ -42,7 +42,7 @@ namespace Element
 
         Tag& setCloseable(bool closeable);
         Tag& setRound(bool round);
-        Tag& disableTransitions(bool distrans);
+        Tag& setDisableTransitions(bool distrans);
 
         Tag& setText(const QString& text);
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -316,14 +316,17 @@ void Example::setupTab5()
     connect(ui->button_42, &Button::clicked, this, [&]() {
         Dialog* dialog = new Dialog("Tips", "this is a message dialog", this);
 
-        dialog->setBeforeClose([](std::function<void()> done) {
-            Dialog* qryDlg = new Dialog;
-            qryDlg->setTitle("").setContent("Are you sure to close this dialog?");
+        dialog->setBeforeClose([=](std::function<void()> done) {
+            Dialog* qryDlg = new Dialog("", "Are you sure to close this dialog?", this);
             QObject::connect(qryDlg, &Element::Dialog::accepted, [done]() {
                 done();
             });
-            QObject::connect(qryDlg, &Element::Dialog::rejected, []() {});
-            QObject::connect(qryDlg, &Element::Dialog::closed, []() {});
+            QObject::connect(qryDlg, &Element::Dialog::rejected, [&]() {
+                dialog->getFocus();
+            });
+            QObject::connect(qryDlg, &Element::Dialog::closed, [&]() {
+                dialog->getFocus();
+            });
             qryDlg->show();
         });
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -316,22 +316,48 @@ void Example::setupTab5()
     connect(ui->button_42, &Button::clicked, this, [&]() {
         Dialog* dialog = new Dialog("Tips", "this is a message dialog", this);
 
-        dialog->setBeforeClose([=](std::function<void()> done) {
+        connect(dialog, &Dialog::opened, [](){
+            qDebug()<<"Dialog emitted an opened signal.";
+        });
+
+        connect(dialog, &Dialog::accepted, [dialog](){
+            qDebug()<<"Dialog emitted an accepted signal.";
+            dialog->closeDialog();
+        });
+
+        connect(dialog, &Dialog::rejected, [dialog](){
+            qDebug()<<"Dialog emitted an rejected signal.";
+            dialog->closeDialog();
+        });
+
+        connect(dialog, &Dialog::closed, [](){
+            qDebug()<<"Dialog emitted an closed signal.";
+        });
+
+        dialog->setBeforeClose([=](std::function<void()> done)
+        {
             Dialog* qryDlg = new Dialog("", "Are you sure to close this dialog?", this);
-            QObject::connect(qryDlg, &Element::Dialog::accepted, [done]() {
-                done();
+
+            connect(qryDlg, &Element::Dialog::accepted, [qryDlg, done]() {
+                qryDlg->closeDialog();
+                connect(qryDlg, &Dialog::closed, [done](){done();});
             });
-            QObject::connect(qryDlg, &Element::Dialog::rejected, [&]() {
-                dialog->getFocus();
+
+            connect(qryDlg, &Element::Dialog::rejected, [qryDlg, dialog]() {
+                qryDlg->closeDialog();
+                connect(qryDlg, &Dialog::closed, [dialog](){dialog->setFocus();});
             });
-            QObject::connect(qryDlg, &Element::Dialog::closed, [&]() {
-                dialog->getFocus();
+
+            connect(qryDlg, &Element::Dialog::closed, [dialog]() {
+                dialog->setFocus();
             });
+
             qryDlg->show();
         });
 
         dialog->show();
     });
+
     connect(ui->button_43, &Button::clicked, this, [&]() {
         Message* message = new Message("This is a message.", " VNode", this);
         message->setType(Message::Type::Info);
@@ -383,7 +409,6 @@ void Example::setupTab5()
         message->show();
     });
 
-    //带回调函数
     connect(ui->button_65, &Button::clicked, this, [&]() {
         Message* message = new Message("Terminal output a message.", this);
         message->setAutoClose(false);
@@ -603,12 +628,42 @@ void Example::setupTab10()
     setLabel(ui->label_task);
 
     Drawer* drawer = new Drawer(this);
-    connect(drawer, &Drawer::confirm, []() {
-        qDebug() << "Confirm Button Clicked";
+
+    connect(drawer, &Drawer::opened, []() {
+        qDebug()<<"Drawer emitted an opened signal.";
+    });
+
+    connect(drawer, &Drawer::accepted, [drawer]() {
+        qDebug()<<"Drawer emitted an accepted signal.";
+        drawer->closeDrawer();
+    });
+
+    connect(drawer, &Drawer::rejected, [drawer]() {
+        qDebug()<<"Drawer emitted an rejected signal.";
+        drawer->closeDrawer();
+    });
+
+    connect(drawer, &Drawer::closed, []() {
+        qDebug()<<"Drawer emitted an closed signal.";
+    });
+
+    drawer->setBeforeClose([=](std::function<void()> done) {
+        Dialog* qryDlg = new Dialog("", "Are you sure to close this Drawer?", this);
+
+        connect(qryDlg, &Element::Dialog::accepted, [qryDlg, done]() {
+            qryDlg->closeDialog();
+            connect(qryDlg, &Dialog::closed, [done](){done();});
+        });
+
+        connect(qryDlg, &Element::Dialog::rejected, [qryDlg]() {
+            qryDlg->closeDialog();
+        });
+
+        qryDlg->show();
     });
 
     connect(ui->button_64, &Button::clicked, [drawer]() {
-        drawer->setVisible(!drawer->isVisible());
+        drawer->show();
     });
 
     ui->progress_1->setPercentage(50)

--- a/example/example.ui
+++ b/example/example.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>10</number>
+       <number>6</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideNone</enum>
@@ -2425,7 +2425,7 @@
          </rect>
         </property>
         <property name="currentIndex">
-         <number>3</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="tab1_tabs">
          <attribute name="title">

--- a/example/example.ui
+++ b/example/example.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>6</number>
+       <number>10</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideNone</enum>
@@ -2415,134 +2415,222 @@
        <attribute name="title">
         <string>页面</string>
        </attribute>
-       <widget class="Element::Tabs" name="tabs">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>30</y>
-          <width>461</width>
-          <height>381</height>
-         </rect>
-        </property>
-        <property name="currentIndex">
+       <layout class="QVBoxLayout" name="verticalLayout_9">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <widget class="QWidget" name="tab1_tabs">
-         <attribute name="title">
-          <string>User</string>
-         </attribute>
-         <widget class="QLabel" name="label_user">
-          <property name="geometry">
-           <rect>
-            <x>40</x>
-            <y>40</y>
-            <width>121</width>
-            <height>51</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>User</string>
-          </property>
-         </widget>
-        </widget>
-        <widget class="QWidget" name="tab2_tabs">
-         <attribute name="title">
-          <string>Config</string>
-         </attribute>
-         <widget class="QLabel" name="label_config">
-          <property name="geometry">
-           <rect>
-            <x>40</x>
-            <y>40</y>
-            <width>121</width>
-            <height>51</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Config</string>
-          </property>
-         </widget>
-        </widget>
-        <widget class="QWidget" name="tab3_tabs">
-         <attribute name="title">
-          <string>Role</string>
-         </attribute>
-         <widget class="QLabel" name="label_role">
-          <property name="geometry">
-           <rect>
-            <x>40</x>
-            <y>40</y>
-            <width>121</width>
-            <height>51</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Role</string>
-          </property>
-         </widget>
-        </widget>
-        <widget class="QWidget" name="tab4_tabs">
-         <attribute name="title">
-          <string>Task</string>
-         </attribute>
-         <widget class="QLabel" name="label_task">
-          <property name="geometry">
-           <rect>
-            <x>40</x>
-            <y>40</y>
-            <width>121</width>
-            <height>51</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Task</string>
-          </property>
-         </widget>
-        </widget>
-       </widget>
-       <widget class="Element::Button" name="button_64">
-        <property name="geometry">
-         <rect>
-          <x>30</x>
-          <y>490</y>
-          <width>121</width>
-          <height>31</height>
-         </rect>
+        <property name="leftMargin">
+         <number>30</number>
         </property>
-        <property name="text">
-         <string>open drawer</string>
+        <property name="topMargin">
+         <number>30</number>
         </property>
-       </widget>
-       <widget class="Element::Progress" name="progress_1" native="true">
-        <property name="geometry">
-         <rect>
-          <x>500</x>
-          <y>30</y>
-          <width>500</width>
-          <height>30</height>
-         </rect>
+        <property name="rightMargin">
+         <number>30</number>
         </property>
-       </widget>
-       <widget class="Element::Progress" name="progress_2" native="true">
-        <property name="geometry">
-         <rect>
-          <x>500</x>
-          <y>90</y>
-          <width>200</width>
-          <height>150</height>
-         </rect>
+        <property name="bottomMargin">
+         <number>30</number>
         </property>
-       </widget>
-       <widget class="Element::Progress" name="progress_3" native="true">
-        <property name="geometry">
-         <rect>
-          <x>730</x>
-          <y>90</y>
-          <width>200</width>
-          <height>150</height>
-         </rect>
-        </property>
-       </widget>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <property name="spacing">
+           <number>40</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15" stretch="6,4,6">
+            <property name="spacing">
+             <number>50</number>
+            </property>
+            <item>
+             <widget class="Element::Tabs" name="tabs">
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <widget class="QWidget" name="tab1_tabs">
+               <attribute name="title">
+                <string>User</string>
+               </attribute>
+               <widget class="QLabel" name="label_user">
+                <property name="geometry">
+                 <rect>
+                  <x>40</x>
+                  <y>40</y>
+                  <width>121</width>
+                  <height>51</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>User</string>
+                </property>
+               </widget>
+              </widget>
+              <widget class="QWidget" name="tab2_tabs">
+               <attribute name="title">
+                <string>Config</string>
+               </attribute>
+               <widget class="QLabel" name="label_config">
+                <property name="geometry">
+                 <rect>
+                  <x>40</x>
+                  <y>40</y>
+                  <width>121</width>
+                  <height>51</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>Config</string>
+                </property>
+               </widget>
+              </widget>
+              <widget class="QWidget" name="tab3_tabs">
+               <attribute name="title">
+                <string>Role</string>
+               </attribute>
+               <widget class="QLabel" name="label_role">
+                <property name="geometry">
+                 <rect>
+                  <x>40</x>
+                  <y>40</y>
+                  <width>121</width>
+                  <height>51</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>Role</string>
+                </property>
+               </widget>
+              </widget>
+              <widget class="QWidget" name="tab4_tabs">
+               <attribute name="title">
+                <string>Task</string>
+               </attribute>
+               <widget class="QLabel" name="label_task">
+                <property name="geometry">
+                 <rect>
+                  <x>40</x>
+                  <y>40</y>
+                  <width>121</width>
+                  <height>51</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>Task</string>
+                </property>
+               </widget>
+              </widget>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_18">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>60</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,6,0">
+              <property name="spacing">
+               <number>20</number>
+              </property>
+              <item>
+               <widget class="Element::Progress" name="progress_1" native="true"/>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_14">
+                <property name="spacing">
+                 <number>30</number>
+                </property>
+                <item>
+                 <widget class="Element::Progress" name="progress_2" native="true">
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>150</height>
+                   </size>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Progress" name="progress_3" native="true">
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>150</height>
+                   </size>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_8">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_16">
+            <item>
+             <widget class="Element::Button" name="button_64">
+              <property name="text">
+               <string>open drawer</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_17">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
       <widget class="QWidget" name="tab_11">
        <attribute name="title">

--- a/example/example.ui
+++ b/example/example.ui
@@ -14,2582 +14,2904 @@
    <string/>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="Element::TabWidget" name="tabWidget">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>1280</width>
-      <height>780</height>
-     </rect>
+   <layout class="QVBoxLayout" name="verticalLayout_5">
+    <property name="spacing">
+     <number>0</number>
     </property>
-    <property name="tabShape">
-     <enum>QTabWidget::Rounded</enum>
+    <property name="leftMargin">
+     <number>0</number>
     </property>
-    <property name="currentIndex">
-     <number>5</number>
+    <property name="topMargin">
+     <number>0</number>
     </property>
-    <property name="elideMode">
-     <enum>Qt::ElideNone</enum>
+    <property name="rightMargin">
+     <number>0</number>
     </property>
-    <property name="documentMode">
-     <bool>false</bool>
+    <property name="bottomMargin">
+     <number>0</number>
     </property>
-    <property name="tabsClosable">
-     <bool>false</bool>
-    </property>
-    <property name="movable">
-     <bool>false</bool>
-    </property>
-    <property name="tabBarAutoHide">
-     <bool>false</bool>
-    </property>
-    <widget class="QWidget" name="tab_0">
-     <attribute name="title">
-      <string>文本</string>
-     </attribute>
-     <widget class="QPlainTextEdit" name="shadow_1">
-      <property name="geometry">
-       <rect>
-        <x>60</x>
-        <y>250</y>
-        <width>160</width>
-        <height>160</height>
-       </rect>
+    <item>
+     <widget class="Element::TabWidget" name="tabWidget">
+      <property name="tabShape">
+       <enum>QTabWidget::Rounded</enum>
       </property>
-     </widget>
-     <widget class="QPlainTextEdit" name="shadow_2">
-      <property name="geometry">
-       <rect>
-        <x>270</x>
-        <y>250</y>
-        <width>160</width>
-        <height>160</height>
-       </rect>
+      <property name="currentIndex">
+       <number>10</number>
       </property>
-     </widget>
-     <widget class="QPlainTextEdit" name="shadow_3">
-      <property name="geometry">
-       <rect>
-        <x>480</x>
-        <y>250</y>
-        <width>160</width>
-        <height>160</height>
-       </rect>
+      <property name="elideMode">
+       <enum>Qt::ElideNone</enum>
       </property>
-     </widget>
-     <widget class="QPlainTextEdit" name="shadow_4">
-      <property name="geometry">
-       <rect>
-        <x>690</x>
-        <y>250</y>
-        <width>160</width>
-        <height>160</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QScrollBar" name="scrollbar">
-      <property name="geometry">
-       <rect>
-        <x>1110</x>
-        <y>120</y>
-        <width>16</width>
-        <height>391</height>
-       </rect>
-      </property>
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-     </widget>
-     <widget class="QWidget" name="showText" native="true">
-      <property name="geometry">
-       <rect>
-        <x>90</x>
-        <y>120</y>
-        <width>741</width>
-        <height>61</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="Element::Text" name="defaultText">
-         <property name="text">
-          <string>Default</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Text" name="primaryText">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Text" name="successText">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Text" name="infoText">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Text" name="warningText">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Text" name="dangerText">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_1">
-     <attribute name="title">
-      <string>按钮</string>
-     </attribute>
-     <widget class="QWidget" name="horizontalLayoutWidget_2">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>595</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="Element::Button" name="button_1">
-         <property name="text">
-          <string>Default</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_2">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_3">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_4">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_5">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_6">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_3">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>110</y>
-        <width>595</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="Element::Button" name="button_7">
-         <property name="text">
-          <string>Plain</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_8">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_9">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_10">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_11">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_12">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_4">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>210</y>
-        <width>595</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <widget class="Element::Button" name="button_13">
-         <property name="text">
-          <string>Round</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_14">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_15">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_16">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_17">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_18">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_5">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>310</y>
-        <width>331</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <item>
-        <widget class="Element::Button" name="button_19">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_20">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_21">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_22">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_23">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_24">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="Element::Button" name="button_28">
-      <property name="geometry">
-       <rect>
-        <x>230</x>
-        <y>420</y>
-        <width>31</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_25">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>420</y>
-        <width>31</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_26">
-      <property name="geometry">
-       <rect>
-        <x>90</x>
-        <y>420</y>
-        <width>31</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_27">
-      <property name="geometry">
-       <rect>
-        <x>160</x>
-        <y>420</y>
-        <width>31</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_29">
-      <property name="geometry">
-       <rect>
-        <x>360</x>
-        <y>420</y>
-        <width>31</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_6">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>470</y>
-        <width>595</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
-        <widget class="Element::Button" name="button_30">
-         <property name="text">
-          <string>Link</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_31">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_32">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_33">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_34">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_35">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_7">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>570</y>
-        <width>595</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <widget class="Element::Button" name="button_36">
-         <property name="text">
-          <string>Text</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_37">
-         <property name="text">
-          <string>Primary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_38">
-         <property name="text">
-          <string>Success</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_39">
-         <property name="text">
-          <string>Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_40">
-         <property name="text">
-          <string>Warning</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Element::Button" name="button_41">
-         <property name="text">
-          <string>Danger</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_2">
-     <attribute name="title">
-      <string>滚动条</string>
-     </attribute>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>30</y>
-        <width>721</width>
-        <height>551</height>
-       </rect>
-      </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>719</width>
-         <height>549</height>
-        </rect>
-       </property>
-      </widget>
-     </widget>
-     <widget class="Element::Backtop" name="backtop">
-      <property name="geometry">
-       <rect>
-        <x>920</x>
-        <y>620</y>
-        <width>60</width>
-        <height>60</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>backtop</string>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_3">
-     <attribute name="title">
-      <string>链接</string>
-     </attribute>
-     <widget class="Element::Link" name="link_1">
-      <property name="geometry">
-       <rect>
-        <x>250</x>
-        <y>190</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>default</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_2">
-      <property name="geometry">
-       <rect>
-        <x>360</x>
-        <y>190</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>primary</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_3">
-      <property name="geometry">
-       <rect>
-        <x>470</x>
-        <y>190</y>
-        <width>55</width>
-        <height>19</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>success</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_4">
-      <property name="geometry">
-       <rect>
-        <x>570</x>
-        <y>190</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>warning</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_5">
-      <property name="geometry">
-       <rect>
-        <x>680</x>
-        <y>190</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>danger</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_6">
-      <property name="geometry">
-       <rect>
-        <x>790</x>
-        <y>190</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>info</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_7">
-      <property name="geometry">
-       <rect>
-        <x>250</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>default</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_8">
-      <property name="geometry">
-       <rect>
-        <x>360</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>primary</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_9">
-      <property name="geometry">
-       <rect>
-        <x>470</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>success</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_10">
-      <property name="geometry">
-       <rect>
-        <x>570</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>warning</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_11">
-      <property name="geometry">
-       <rect>
-        <x>680</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>danger</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_12">
-      <property name="geometry">
-       <rect>
-        <x>790</x>
-        <y>230</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>info</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_13">
-      <property name="geometry">
-       <rect>
-        <x>250</x>
-        <y>280</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>default</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_14">
-      <property name="geometry">
-       <rect>
-        <x>360</x>
-        <y>280</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>always</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_15">
-      <property name="geometry">
-       <rect>
-        <x>470</x>
-        <y>280</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>hover</string>
-      </property>
-     </widget>
-     <widget class="Element::Link" name="link_16">
-      <property name="geometry">
-       <rect>
-        <x>570</x>
-        <y>280</y>
-        <width>72</width>
-        <height>15</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>never</string>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_4">
-     <attribute name="title">
-      <string>输入</string>
-     </attribute>
-     <widget class="Element::InputText" name="input_11">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>620</y>
-        <width>111</width>
-        <height>61</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_01">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>20</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_02">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>80</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_03">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>140</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_04">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>200</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_05">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>260</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_06">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>320</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_07">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>390</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_08">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>440</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_09">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>500</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputLine" name="input_10">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>560</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputText" name="input_12">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>20</y>
-        <width>111</width>
-        <height>61</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputText" name="input_13">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>120</y>
-        <width>111</width>
-        <height>61</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputText" name="input_14">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>220</y>
-        <width>111</width>
-        <height>61</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputNumber" name="spinBox_1">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>320</y>
-        <width>81</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputNumber" name="spinBox_2">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>390</y>
-        <width>81</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputNumber" name="spinBox_3">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>460</y>
-        <width>81</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputNumber" name="spinBox_4">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>530</y>
-        <width>81</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::InputTag" name="input_15">
-      <property name="geometry">
-       <rect>
-        <x>380</x>
-        <y>600</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Autocomplete" name="autocomplete">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>20</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_63">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>340</y>
-        <width>94</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Default</string>
-      </property>
-     </widget>
-     <widget class="Element::Switch" name="switch_1" native="true">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>430</y>
-        <width>61</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Switch" name="switch_2" native="true">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>490</y>
-        <width>61</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Switch" name="switch_3" native="true">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>540</y>
-        <width>61</width>
-        <height>31</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Slider" name="slider_1">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>650</y>
-        <width>160</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-     </widget>
-     <widget class="Element::Slider" name="slider_2">
-      <property name="geometry">
-       <rect>
-        <x>970</x>
-        <y>430</y>
-        <width>22</width>
-        <height>160</height>
-       </rect>
-      </property>
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-     </widget>
-     <widget class="Element::Select" name="select">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>80</y>
-        <width>113</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_5">
-     <attribute name="title">
-      <string>反馈</string>
-     </attribute>
-     <widget class="Element::Button" name="button_42">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>20</y>
-        <width>121</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Open Dialog</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_43">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>90</y>
-        <width>121</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Show message</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_44">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>90</y>
-        <width>91</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Top Left</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_45">
-      <property name="geometry">
-       <rect>
-        <x>310</x>
-        <y>90</y>
-        <width>91</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Top Right</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_46">
-      <property name="geometry">
-       <rect>
-        <x>430</x>
-        <y>90</y>
-        <width>71</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Bottom</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_47">
-      <property name="geometry">
-       <rect>
-        <x>540</x>
-        <y>90</y>
-        <width>101</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Bottom Left</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_48">
-      <property name="geometry">
-       <rect>
-        <x>680</x>
-        <y>90</y>
-        <width>111</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Bottom Right</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_49">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>150</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Primary</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_50">
-      <property name="geometry">
-       <rect>
-        <x>310</x>
-        <y>150</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Success</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_51">
-      <property name="geometry">
-       <rect>
-        <x>420</x>
-        <y>150</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Warning</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_52">
-      <property name="geometry">
-       <rect>
-        <x>540</x>
-        <y>150</y>
-        <width>71</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Info</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_53">
-      <property name="geometry">
-       <rect>
-        <x>620</x>
-        <y>150</y>
-        <width>71</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Error</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_54">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>230</y>
-        <width>121</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Notification</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_55">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>230</y>
-        <width>91</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Top Left</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_56">
-      <property name="geometry">
-       <rect>
-        <x>310</x>
-        <y>230</y>
-        <width>101</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Bottom Left</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_57">
-      <property name="geometry">
-       <rect>
-        <x>450</x>
-        <y>230</y>
-        <width>111</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Bottom Right</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_58">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>290</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Primary</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_59">
-      <property name="geometry">
-       <rect>
-        <x>310</x>
-        <y>290</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Success</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_60">
-      <property name="geometry">
-       <rect>
-        <x>420</x>
-        <y>290</y>
-        <width>81</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Warning</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_61">
-      <property name="geometry">
-       <rect>
-        <x>540</x>
-        <y>290</y>
-        <width>71</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Info</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_62">
-      <property name="geometry">
-       <rect>
-        <x>620</x>
-        <y>290</y>
-        <width>71</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Error</string>
-      </property>
-     </widget>
-     <widget class="Element::Dropdown" name="dropdown" native="true">
-      <property name="geometry">
-       <rect>
-        <x>910</x>
-        <y>30</y>
-        <width>141</width>
-        <height>21</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="button_65">
-      <property name="geometry">
-       <rect>
-        <x>710</x>
-        <y>150</y>
-        <width>93</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>On Close</string>
-      </property>
-     </widget>
-     <widget class="Element::Button" name="pushButton">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>430</y>
-        <width>93</width>
-        <height>28</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Popover</string>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_6">
-     <attribute name="title">
-      <string>数据</string>
-     </attribute>
-     <widget class="Element::Avatar" name="avatar">
-      <property name="geometry">
-       <rect>
-        <x>40</x>
-        <y>30</y>
-        <width>80</width>
-        <height>80</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>avatar</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_01">
-      <property name="geometry">
-       <rect>
-        <x>160</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_02">
-      <property name="geometry">
-       <rect>
-        <x>230</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_03">
-      <property name="geometry">
-       <rect>
-        <x>300</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_04">
-      <property name="geometry">
-       <rect>
-        <x>370</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_05">
-      <property name="geometry">
-       <rect>
-        <x>440</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_21">
-      <property name="geometry">
-       <rect>
-        <x>160</x>
-        <y>130</y>
-        <width>81</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_22">
-      <property name="geometry">
-       <rect>
-        <x>250</x>
-        <y>130</y>
-        <width>81</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_23">
-      <property name="geometry">
-       <rect>
-        <x>340</x>
-        <y>130</y>
-        <width>81</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_24">
-      <property name="geometry">
-       <rect>
-        <x>430</x>
-        <y>130</y>
-        <width>81</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_25">
-      <property name="geometry">
-       <rect>
-        <x>520</x>
-        <y>130</y>
-        <width>81</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_06">
-      <property name="geometry">
-       <rect>
-        <x>530</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_07">
-      <property name="geometry">
-       <rect>
-        <x>600</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_08">
-      <property name="geometry">
-       <rect>
-        <x>670</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_09">
-      <property name="geometry">
-       <rect>
-        <x>740</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_10">
-      <property name="geometry">
-       <rect>
-        <x>810</x>
-        <y>30</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_11">
-      <property name="geometry">
-       <rect>
-        <x>160</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_12">
-      <property name="geometry">
-       <rect>
-        <x>230</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_13">
-      <property name="geometry">
-       <rect>
-        <x>300</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_14">
-      <property name="geometry">
-       <rect>
-        <x>370</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_15">
-      <property name="geometry">
-       <rect>
-        <x>440</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_16">
-      <property name="geometry">
-       <rect>
-        <x>530</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_17">
-      <property name="geometry">
-       <rect>
-        <x>600</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_18">
-      <property name="geometry">
-       <rect>
-        <x>670</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_19">
-      <property name="geometry">
-       <rect>
-        <x>740</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Tag" name="tag_20">
-      <property name="geometry">
-       <rect>
-        <x>810</x>
-        <y>80</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Tag 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Table" name="table">
-      <property name="geometry">
-       <rect>
-        <x>40</x>
-        <y>190</y>
-        <width>851</width>
-        <height>251</height>
-       </rect>
-      </property>
-      <property name="rowCount">
-       <number>4</number>
-      </property>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <column>
-       <property name="text">
-        <string>Date</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Name</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Address</string>
-       </property>
-      </column>
-      <item row="0" column="0">
-       <property name="text">
-        <string>2016-05-03</string>
-       </property>
-      </item>
-      <item row="0" column="1">
-       <property name="text">
-        <string>Tom</string>
-       </property>
-      </item>
-      <item row="0" column="2">
-       <property name="text">
-        <string>No. 189, Grove St, Los Angeles</string>
-       </property>
-      </item>
-      <item row="1" column="0">
-       <property name="text">
-        <string>2016-05-02</string>
-       </property>
-      </item>
-      <item row="1" column="1">
-       <property name="text">
-        <string>Tom</string>
-       </property>
-      </item>
-      <item row="1" column="2">
-       <property name="text">
-        <string>No. 189, Grove St, Los Angeles</string>
-       </property>
-      </item>
-      <item row="2" column="0">
-       <property name="text">
-        <string>2016-05-04</string>
-       </property>
-      </item>
-      <item row="2" column="1">
-       <property name="text">
-        <string>Tom</string>
-       </property>
-      </item>
-      <item row="2" column="2">
-       <property name="text">
-        <string>No. 189, Grove St, Los Angeles</string>
-       </property>
-      </item>
-      <item row="3" column="0">
-       <property name="text">
-        <string>2016-05-01</string>
-       </property>
-      </item>
-      <item row="3" column="1">
-       <property name="text">
-        <string>Tom</string>
-       </property>
-      </item>
-      <item row="3" column="2">
-       <property name="text">
-        <string>No. 189, Grove St, Los Angeles</string>
-       </property>
-      </item>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_7">
-     <attribute name="title">
-      <string>面板</string>
-     </attribute>
-     <widget class="Element::Card" name="card_1" native="true">
-      <property name="geometry">
-       <rect>
-        <x>40</x>
-        <y>30</y>
-        <width>361</width>
-        <height>370</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Card" name="card_2" native="true">
-      <property name="geometry">
-       <rect>
-        <x>430</x>
-        <y>30</y>
-        <width>361</width>
-        <height>370</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::CollapseItem" name="collapseItem" native="true">
-      <property name="geometry">
-       <rect>
-        <x>40</x>
-        <y>440</y>
-        <width>900</width>
-        <height>180</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_8">
-     <attribute name="title">
-      <string>进度</string>
-     </attribute>
-     <widget class="Element::Collapse" name="collapse" native="true">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>30</y>
-        <width>900</width>
-        <height>250</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Upload" name="upload_1" native="true">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>320</y>
-        <width>450</width>
-        <height>420</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Upload" name="upload_2" native="true">
-      <property name="geometry">
-       <rect>
-        <x>560</x>
-        <y>320</y>
-        <width>450</width>
-        <height>300</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_9">
-     <attribute name="title">
-      <string>表单</string>
-     </attribute>
-     <widget class="Element::Checkbox" name="checkbox_1">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>20</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_5">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>130</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_3">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>80</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_6">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>130</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 6</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_4">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>80</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_2">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>20</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Checkbox" name="checkbox_7">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>190</y>
-        <width>101</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Check All</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_1">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>340</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 1</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_2">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>340</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 2</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_3">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>400</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 3</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_4">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>400</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 4</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_5">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>460</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 5</string>
-      </property>
-     </widget>
-     <widget class="Element::Radio" name="radio_6">
-      <property name="geometry">
-       <rect>
-        <x>200</x>
-        <y>460</y>
-        <width>91</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Option 6</string>
-      </property>
-     </widget>
-     <widget class="Element::RadioGroup" name="radioGroup">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>510</y>
-        <width>331</width>
-        <height>61</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>GroupBox</string>
-      </property>
-      <widget class="Element::Radio" name="radio_7">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>91</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Option 7</string>
-       </property>
-      </widget>
-      <widget class="Element::Radio" name="radio_8">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>20</y>
-         <width>91</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Option 8</string>
-       </property>
-      </widget>
-      <widget class="Element::Radio" name="radio_9">
-       <property name="geometry">
-        <rect>
-         <x>220</x>
-         <y>20</y>
-         <width>91</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Option 9</string>
-       </property>
-      </widget>
-     </widget>
-     <widget class="Element::CheckboxGroup" name="checkboxGroup">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>230</y>
-        <width>341</width>
-        <height>61</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>GroupBox</string>
-      </property>
-      <widget class="Element::Checkbox" name="checkbox_8">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>91</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Beijing</string>
-       </property>
-      </widget>
-      <widget class="Element::Checkbox" name="checkbox_9">
-       <property name="geometry">
-        <rect>
-         <x>110</x>
-         <y>20</y>
-         <width>101</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Shanghai</string>
-       </property>
-      </widget>
-      <widget class="Element::Checkbox" name="checkbox_10">
-       <property name="geometry">
-        <rect>
-         <x>230</x>
-         <y>20</y>
-         <width>111</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Guangzhou</string>
-       </property>
-      </widget>
-     </widget>
-     <widget class="Element::Rate" name="rate" native="true">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>610</y>
-        <width>251</width>
-        <height>51</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Menu" name="menu">
-      <property name="geometry">
-       <rect>
-        <x>470</x>
-        <y>20</y>
-        <width>181</width>
-        <height>531</height>
-       </rect>
-      </property>
-      <attribute name="headerVisible">
+      <property name="documentMode">
        <bool>false</bool>
-      </attribute>
-      <column>
-       <property name="text">
-        <string notr="true">1</string>
-       </property>
-      </column>
-     </widget>
-     <widget class="Element::Stack" name="stack">
-      <property name="geometry">
-       <rect>
-        <x>660</x>
-        <y>20</y>
-        <width>461</width>
-        <height>431</height>
-       </rect>
       </property>
-      <property name="currentIndex">
-       <number>-1</number>
+      <property name="tabsClosable">
+       <bool>false</bool>
       </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_10">
-     <attribute name="title">
-      <string>页面</string>
-     </attribute>
-     <widget class="Element::Tabs" name="tabs">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>30</y>
-        <width>461</width>
-        <height>381</height>
-       </rect>
+      <property name="movable">
+       <bool>false</bool>
       </property>
-      <property name="currentIndex">
-       <number>3</number>
+      <property name="tabBarAutoHide">
+       <bool>false</bool>
       </property>
-      <widget class="QWidget" name="tab1_tabs">
+      <widget class="QWidget" name="tab_0">
        <attribute name="title">
-        <string>User</string>
+        <string>文本</string>
        </attribute>
-       <widget class="QLabel" name="label_user">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>40</y>
-          <width>121</width>
-          <height>51</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>User</string>
-        </property>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>50</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>100</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QWidget" name="showText" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <property name="spacing">
+                <number>50</number>
+               </property>
+               <item>
+                <widget class="Element::Text" name="defaultText">
+                 <property name="text">
+                  <string>Default</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Element::Text" name="primaryText">
+                 <property name="text">
+                  <string>Primary</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Element::Text" name="successText">
+                 <property name="text">
+                  <string>Success</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Element::Text" name="infoText">
+                 <property name="text">
+                  <string>Info</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Element::Text" name="warningText">
+                 <property name="text">
+                  <string>Warning</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Element::Text" name="dangerText">
+                 <property name="text">
+                  <string>Danger</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>60</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>100</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="shadow_1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>160</width>
+                <height>160</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>48</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="shadow_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>160</width>
+                <height>160</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>48</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="shadow_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>160</width>
+                <height>160</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>48</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="shadow_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>160</width>
+                <height>160</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
-      <widget class="QWidget" name="tab2_tabs">
+      <widget class="QWidget" name="tab_1">
        <attribute name="title">
-        <string>Config</string>
+        <string>按钮</string>
        </attribute>
-       <widget class="QLabel" name="label_config">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>40</y>
-          <width>121</width>
-          <height>51</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Config</string>
-        </property>
-       </widget>
-      </widget>
-      <widget class="QWidget" name="tab3_tabs">
-       <attribute name="title">
-        <string>Role</string>
-       </attribute>
-       <widget class="QLabel" name="label_role">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>40</y>
-          <width>121</width>
-          <height>51</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Role</string>
-        </property>
-       </widget>
-      </widget>
-      <widget class="QWidget" name="tab4_tabs">
-       <attribute name="title">
-        <string>Task</string>
-       </attribute>
-       <widget class="QLabel" name="label_task">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>40</y>
-          <width>121</width>
-          <height>51</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Task</string>
-        </property>
-       </widget>
-      </widget>
-     </widget>
-     <widget class="Element::Button" name="button_64">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>490</y>
-        <width>121</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>open drawer</string>
-      </property>
-     </widget>
-     <widget class="Element::Progress" name="progress_1" native="true">
-      <property name="geometry">
-       <rect>
-        <x>500</x>
-        <y>30</y>
-        <width>500</width>
-        <height>30</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Progress" name="progress_2" native="true">
-      <property name="geometry">
-       <rect>
-        <x>500</x>
-        <y>90</y>
-        <width>200</width>
-        <height>150</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Progress" name="progress_3" native="true">
-      <property name="geometry">
-       <rect>
-        <x>730</x>
-        <y>90</y>
-        <width>200</width>
-        <height>150</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="tab_11">
-     <attribute name="title">
-      <string>其他</string>
-     </attribute>
-     <widget class="Element::Carousel" name="carousel" native="true">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>20</y>
-        <width>501</width>
-        <height>261</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="Element::Image" name="image" native="true">
-      <property name="geometry">
-       <rect>
-        <x>660</x>
-        <y>20</y>
-        <width>300</width>
-        <height>281</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QWidget" name="widget" native="true">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>310</y>
-        <width>1061</width>
-        <height>411</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true"/>
-      </property>
-      <widget class="QWidget" name="widget_3" native="true">
-       <property name="geometry">
-        <rect>
-         <x>740</x>
-         <y>70</y>
-         <width>271</width>
-         <height>41</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <widget class="QLabel" name="dividerText_6">
+       <widget class="QWidget" name="horizontalLayoutWidget_2">
         <property name="geometry">
          <rect>
           <x>20</x>
           <y>10</y>
-          <width>61</width>
-          <height>21</height>
+          <width>595</width>
+          <height>80</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>雨纷纷</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="Element::Button" name="button_1">
+           <property name="text">
+            <string>Default</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_2">
+           <property name="text">
+            <string>Primary</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_3">
+           <property name="text">
+            <string>Success</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_4">
+           <property name="text">
+            <string>Info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_5">
+           <property name="text">
+            <string>Warning</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_6">
+           <property name="text">
+            <string>Danger</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
-       <widget class="QLabel" name="dividerText_7">
+       <widget class="QWidget" name="horizontalLayoutWidget_3">
         <property name="geometry">
          <rect>
-          <x>80</x>
-          <y>10</y>
-          <width>61</width>
-          <height>21</height>
+          <x>20</x>
+          <y>110</y>
+          <width>595</width>
+          <height>80</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="Element::Button" name="button_7">
+           <property name="text">
+            <string>Plain</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_8">
+           <property name="text">
+            <string>Primary</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_9">
+           <property name="text">
+            <string>Success</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_10">
+           <property name="text">
+            <string>Info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_11">
+           <property name="text">
+            <string>Warning</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_12">
+           <property name="text">
+            <string>Danger</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_4">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>210</y>
+          <width>595</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="Element::Button" name="button_13">
+           <property name="text">
+            <string>Round</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_14">
+           <property name="text">
+            <string>Primary</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_15">
+           <property name="text">
+            <string>Success</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_16">
+           <property name="text">
+            <string>Info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_17">
+           <property name="text">
+            <string>Warning</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_18">
+           <property name="text">
+            <string>Danger</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_5">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>310</y>
+          <width>331</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="Element::Button" name="button_19">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_20">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_21">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_22">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_23">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_24">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="Element::Button" name="button_28">
+        <property name="geometry">
+         <rect>
+          <x>230</x>
+          <y>420</y>
+          <width>31</width>
+          <height>28</height>
+         </rect>
         </property>
         <property name="text">
-         <string>旧故里</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <string/>
         </property>
        </widget>
-       <widget class="QLabel" name="dividerText_8">
+       <widget class="Element::Button" name="button_25">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>420</y>
+          <width>31</width>
+          <height>28</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+       <widget class="Element::Button" name="button_26">
+        <property name="geometry">
+         <rect>
+          <x>90</x>
+          <y>420</y>
+          <width>31</width>
+          <height>28</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+       <widget class="Element::Button" name="button_27">
+        <property name="geometry">
+         <rect>
+          <x>160</x>
+          <y>420</y>
+          <width>31</width>
+          <height>28</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+       <widget class="Element::Button" name="button_29">
+        <property name="geometry">
+         <rect>
+          <x>360</x>
+          <y>420</y>
+          <width>31</width>
+          <height>28</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_6">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>470</y>
+          <width>595</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="Element::Button" name="button_30">
+           <property name="text">
+            <string>Link</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_31">
+           <property name="text">
+            <string>Primary</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_32">
+           <property name="text">
+            <string>Success</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_33">
+           <property name="text">
+            <string>Info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_34">
+           <property name="text">
+            <string>Warning</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_35">
+           <property name="text">
+            <string>Danger</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_7">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>570</y>
+          <width>595</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <widget class="Element::Button" name="button_36">
+           <property name="text">
+            <string>Text</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_37">
+           <property name="text">
+            <string>Primary</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_38">
+           <property name="text">
+            <string>Success</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_39">
+           <property name="text">
+            <string>Info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_40">
+           <property name="text">
+            <string>Warning</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Element::Button" name="button_41">
+           <property name="text">
+            <string>Danger</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_2">
+       <attribute name="title">
+        <string>滚动条</string>
+       </attribute>
+       <widget class="QScrollArea" name="scrollArea">
         <property name="geometry">
          <rect>
           <x>140</x>
-          <y>10</y>
-          <width>61</width>
-          <height>21</height>
+          <y>30</y>
+          <width>721</width>
+          <height>551</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>719</width>
+           <height>549</height>
+          </rect>
+         </property>
+        </widget>
+       </widget>
+       <widget class="Element::Backtop" name="backtop">
+        <property name="geometry">
+         <rect>
+          <x>920</x>
+          <y>620</y>
+          <width>60</width>
+          <height>60</height>
+         </rect>
         </property>
         <property name="text">
-         <string>草木深</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <string>backtop</string>
         </property>
        </widget>
       </widget>
-      <widget class="QWidget" name="widget_1" native="true">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>10</y>
-         <width>591</width>
-         <height>121</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <widget class="QLabel" name="dividerText_1">
+      <widget class="QWidget" name="tab_3">
+       <attribute name="title">
+        <string>链接</string>
+       </attribute>
+       <widget class="Element::Link" name="link_1">
         <property name="geometry">
          <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>491</width>
-          <height>21</height>
+          <x>250</x>
+          <y>190</y>
+          <width>72</width>
+          <height>15</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
         <property name="text">
-         <string>青春是一个短暂的美梦, 当你醒来时, 它早已消失无踪</string>
+         <string>default</string>
         </property>
        </widget>
-       <widget class="QLabel" name="dividerText_2">
+       <widget class="Element::Link" name="link_2">
         <property name="geometry">
          <rect>
-          <x>20</x>
-          <y>70</y>
-          <width>461</width>
-          <height>21</height>
+          <x>360</x>
+          <y>190</y>
+          <width>72</width>
+          <height>15</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
+        <property name="text">
+         <string>primary</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_3">
+        <property name="geometry">
+         <rect>
+          <x>470</x>
+          <y>190</y>
+          <width>55</width>
+          <height>19</height>
+         </rect>
         </property>
         <property name="text">
-         <string>少量的邪恶足以抵消全部高贵的品质, 害得人声名狼藉</string>
+         <string>success</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_4">
+        <property name="geometry">
+         <rect>
+          <x>570</x>
+          <y>190</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>warning</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_5">
+        <property name="geometry">
+         <rect>
+          <x>680</x>
+          <y>190</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>danger</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_6">
+        <property name="geometry">
+         <rect>
+          <x>790</x>
+          <y>190</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>info</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_7">
+        <property name="geometry">
+         <rect>
+          <x>250</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>default</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_8">
+        <property name="geometry">
+         <rect>
+          <x>360</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>primary</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_9">
+        <property name="geometry">
+         <rect>
+          <x>470</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>success</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_10">
+        <property name="geometry">
+         <rect>
+          <x>570</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>warning</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_11">
+        <property name="geometry">
+         <rect>
+          <x>680</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>danger</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_12">
+        <property name="geometry">
+         <rect>
+          <x>790</x>
+          <y>230</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>info</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_13">
+        <property name="geometry">
+         <rect>
+          <x>250</x>
+          <y>280</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>default</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_14">
+        <property name="geometry">
+         <rect>
+          <x>360</x>
+          <y>280</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>always</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_15">
+        <property name="geometry">
+         <rect>
+          <x>470</x>
+          <y>280</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>hover</string>
+        </property>
+       </widget>
+       <widget class="Element::Link" name="link_16">
+        <property name="geometry">
+         <rect>
+          <x>570</x>
+          <y>280</y>
+          <width>72</width>
+          <height>15</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>never</string>
         </property>
        </widget>
       </widget>
-      <widget class="QWidget" name="widget_2" native="true">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>150</y>
-         <width>641</width>
-         <height>271</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">border-color: rgb(184, 184, 184);</string>
-       </property>
-       <widget class="QLabel" name="dividerText_3">
+      <widget class="QWidget" name="tab_4">
+       <attribute name="title">
+        <string>输入</string>
+       </attribute>
+       <widget class="Element::InputText" name="input_11">
         <property name="geometry">
          <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>381</width>
+          <x>50</x>
+          <y>620</y>
+          <width>111</width>
+          <height>61</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_01">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>20</y>
+          <width>113</width>
           <height>21</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>头上一片晴天，心中一个想念</string>
-        </property>
        </widget>
-       <widget class="QLabel" name="dividerText_4">
+       <widget class="Element::InputLine" name="input_02">
         <property name="geometry">
          <rect>
-          <x>30</x>
+          <x>50</x>
           <y>80</y>
-          <width>381</width>
+          <width>113</width>
           <height>21</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>饿了别叫妈, 叫饿了么</string>
+       </widget>
+       <widget class="Element::InputLine" name="input_03">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>140</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
         </property>
        </widget>
-       <widget class="QLabel" name="dividerText_5">
+       <widget class="Element::InputLine" name="input_04">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>200</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_05">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>260</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_06">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>320</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_07">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>390</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_08">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>440</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_09">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>500</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputLine" name="input_10">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>560</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputText" name="input_12">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>20</y>
+          <width>111</width>
+          <height>61</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputText" name="input_13">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>120</y>
+          <width>111</width>
+          <height>61</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputText" name="input_14">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>220</y>
+          <width>111</width>
+          <height>61</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputNumber" name="spinBox_1">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>320</y>
+          <width>81</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputNumber" name="spinBox_2">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>390</y>
+          <width>81</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputNumber" name="spinBox_3">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>460</y>
+          <width>81</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputNumber" name="spinBox_4">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>530</y>
+          <width>81</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::InputTag" name="input_15">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>600</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Autocomplete" name="autocomplete">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>20</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Button" name="button_63">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>340</y>
+          <width>94</width>
+          <height>28</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </widget>
+       <widget class="Element::Switch" name="switch_1" native="true">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>430</y>
+          <width>61</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Switch" name="switch_2" native="true">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>490</y>
+          <width>61</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Switch" name="switch_3" native="true">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>540</y>
+          <width>61</width>
+          <height>31</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Slider" name="slider_1">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>650</y>
+          <width>160</width>
+          <height>22</height>
+         </rect>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+       <widget class="Element::Slider" name="slider_2">
+        <property name="geometry">
+         <rect>
+          <x>970</x>
+          <y>430</y>
+          <width>22</width>
+          <height>160</height>
+         </rect>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+       <widget class="Element::Select" name="select">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>80</y>
+          <width>113</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_5">
+       <attribute name="title">
+        <string>反馈</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="spacing">
+         <number>50</number>
+        </property>
+        <property name="leftMargin">
+         <number>30</number>
+        </property>
+        <property name="topMargin">
+         <number>30</number>
+        </property>
+        <property name="rightMargin">
+         <number>30</number>
+        </property>
+        <property name="bottomMargin">
+         <number>30</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <widget class="Element::Button" name="button_42">
+            <property name="text">
+             <string>Open Dialog</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_14">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="Element::Dropdown" name="dropdown" native="true"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="horizontalSpacing">
+           <number>20</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <item row="0" column="4">
+           <widget class="Element::Button" name="button_46">
+            <property name="text">
+             <string>Bottom</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="Element::Button" name="button_51">
+            <property name="text">
+             <string>Warning</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <spacer name="horizontalSpacer_11">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>16</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="3">
+           <widget class="Element::Button" name="button_50">
+            <property name="text">
+             <string>Success</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5" colspan="2">
+           <widget class="Element::Button" name="button_47">
+            <property name="text">
+             <string>Bottom Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6" colspan="2">
+           <widget class="Element::Button" name="button_53">
+            <property name="text">
+             <string>Error</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="8">
+           <widget class="Element::Button" name="button_65">
+            <property name="text">
+             <string>On Close</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="Element::Button" name="button_49">
+            <property name="text">
+             <string>Primary</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="5">
+           <widget class="Element::Button" name="button_52">
+            <property name="text">
+             <string>Info</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="Element::Button" name="button_44">
+            <property name="text">
+             <string>Top Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="Element::Button" name="button_45">
+            <property name="text">
+             <string>Top Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="Element::Button" name="button_43">
+            <property name="text">
+             <string>Show message</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="7" colspan="2">
+           <widget class="Element::Button" name="button_48">
+            <property name="text">
+             <string>Bottom Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="9">
+           <spacer name="horizontalSpacer_12">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="horizontalSpacing">
+           <number>20</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="Element::Button" name="button_54">
+            <property name="text">
+             <string>Notification</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <spacer name="horizontalSpacer_13">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>42</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="2">
+           <widget class="Element::Button" name="button_55">
+            <property name="text">
+             <string>Top Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3" colspan="2">
+           <widget class="Element::Button" name="button_56">
+            <property name="text">
+             <string>Bottom Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5" colspan="2">
+           <widget class="Element::Button" name="button_57">
+            <property name="text">
+             <string>Bottom Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="8">
+           <spacer name="horizontalSpacer_15">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="2">
+           <widget class="Element::Button" name="button_58">
+            <property name="text">
+             <string>Primary</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="Element::Button" name="button_59">
+            <property name="text">
+             <string>Success</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4" colspan="2">
+           <widget class="Element::Button" name="button_60">
+            <property name="text">
+             <string>Warning</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="Element::Button" name="button_61">
+            <property name="text">
+             <string>Info</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="7">
+           <widget class="Element::Button" name="button_62">
+            <property name="text">
+             <string>Error</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_13">
+          <item>
+           <widget class="Element::Button" name="pushButton">
+            <property name="text">
+             <string>Popover</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_16">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_6">
+       <attribute name="title">
+        <string>数据</string>
+       </attribute>
+       <widget class="Element::Avatar" name="avatar">
         <property name="geometry">
          <rect>
           <x>40</x>
-          <y>140</y>
-          <width>381</width>
+          <y>30</y>
+          <width>80</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>avatar</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_01">
+        <property name="geometry">
+         <rect>
+          <x>160</x>
+          <y>30</y>
+          <width>51</width>
           <height>21</height>
          </rect>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
+        <property name="text">
+         <string>Tag 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_02">
+        <property name="geometry">
+         <rect>
+          <x>230</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
         </property>
         <property name="text">
-         <string>为了无法计算的价值</string>
+         <string>Tag 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_03">
+        <property name="geometry">
+         <rect>
+          <x>300</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_04">
+        <property name="geometry">
+         <rect>
+          <x>370</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_05">
+        <property name="geometry">
+         <rect>
+          <x>440</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_21">
+        <property name="geometry">
+         <rect>
+          <x>160</x>
+          <y>130</y>
+          <width>81</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_22">
+        <property name="geometry">
+         <rect>
+          <x>250</x>
+          <y>130</y>
+          <width>81</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_23">
+        <property name="geometry">
+         <rect>
+          <x>340</x>
+          <y>130</y>
+          <width>81</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_24">
+        <property name="geometry">
+         <rect>
+          <x>430</x>
+          <y>130</y>
+          <width>81</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_25">
+        <property name="geometry">
+         <rect>
+          <x>520</x>
+          <y>130</y>
+          <width>81</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_06">
+        <property name="geometry">
+         <rect>
+          <x>530</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_07">
+        <property name="geometry">
+         <rect>
+          <x>600</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_08">
+        <property name="geometry">
+         <rect>
+          <x>670</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_09">
+        <property name="geometry">
+         <rect>
+          <x>740</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_10">
+        <property name="geometry">
+         <rect>
+          <x>810</x>
+          <y>30</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_11">
+        <property name="geometry">
+         <rect>
+          <x>160</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_12">
+        <property name="geometry">
+         <rect>
+          <x>230</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_13">
+        <property name="geometry">
+         <rect>
+          <x>300</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_14">
+        <property name="geometry">
+         <rect>
+          <x>370</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_15">
+        <property name="geometry">
+         <rect>
+          <x>440</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_16">
+        <property name="geometry">
+         <rect>
+          <x>530</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_17">
+        <property name="geometry">
+         <rect>
+          <x>600</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_18">
+        <property name="geometry">
+         <rect>
+          <x>670</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_19">
+        <property name="geometry">
+         <rect>
+          <x>740</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Tag" name="tag_20">
+        <property name="geometry">
+         <rect>
+          <x>810</x>
+          <y>80</y>
+          <width>51</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Tag 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Table" name="table">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>190</y>
+          <width>851</width>
+          <height>251</height>
+         </rect>
+        </property>
+        <property name="rowCount">
+         <number>4</number>
+        </property>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <column>
+         <property name="text">
+          <string>Date</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Address</string>
+         </property>
+        </column>
+        <item row="0" column="0">
+         <property name="text">
+          <string>2016-05-03</string>
+         </property>
+        </item>
+        <item row="0" column="1">
+         <property name="text">
+          <string>Tom</string>
+         </property>
+        </item>
+        <item row="0" column="2">
+         <property name="text">
+          <string>No. 189, Grove St, Los Angeles</string>
+         </property>
+        </item>
+        <item row="1" column="0">
+         <property name="text">
+          <string>2016-05-02</string>
+         </property>
+        </item>
+        <item row="1" column="1">
+         <property name="text">
+          <string>Tom</string>
+         </property>
+        </item>
+        <item row="1" column="2">
+         <property name="text">
+          <string>No. 189, Grove St, Los Angeles</string>
+         </property>
+        </item>
+        <item row="2" column="0">
+         <property name="text">
+          <string>2016-05-04</string>
+         </property>
+        </item>
+        <item row="2" column="1">
+         <property name="text">
+          <string>Tom</string>
+         </property>
+        </item>
+        <item row="2" column="2">
+         <property name="text">
+          <string>No. 189, Grove St, Los Angeles</string>
+         </property>
+        </item>
+        <item row="3" column="0">
+         <property name="text">
+          <string>2016-05-01</string>
+         </property>
+        </item>
+        <item row="3" column="1">
+         <property name="text">
+          <string>Tom</string>
+         </property>
+        </item>
+        <item row="3" column="2">
+         <property name="text">
+          <string>No. 189, Grove St, Los Angeles</string>
+         </property>
+        </item>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_7">
+       <attribute name="title">
+        <string>面板</string>
+       </attribute>
+       <widget class="Element::Card" name="card_1" native="true">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>30</y>
+          <width>361</width>
+          <height>370</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Card" name="card_2" native="true">
+        <property name="geometry">
+         <rect>
+          <x>430</x>
+          <y>30</y>
+          <width>361</width>
+          <height>370</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::CollapseItem" name="collapseItem" native="true">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>440</y>
+          <width>900</width>
+          <height>180</height>
+         </rect>
         </property>
        </widget>
       </widget>
+      <widget class="QWidget" name="tab_8">
+       <attribute name="title">
+        <string>进度</string>
+       </attribute>
+       <widget class="Element::Collapse" name="collapse" native="true">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>30</y>
+          <width>900</width>
+          <height>250</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Upload" name="upload_1" native="true">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>320</y>
+          <width>450</width>
+          <height>420</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Upload" name="upload_2" native="true">
+        <property name="geometry">
+         <rect>
+          <x>560</x>
+          <y>320</y>
+          <width>450</width>
+          <height>300</height>
+         </rect>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_9">
+       <attribute name="title">
+        <string>表单</string>
+       </attribute>
+       <widget class="Element::Checkbox" name="checkbox_1">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>20</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_5">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>130</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_3">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>80</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_6">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>130</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 6</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_4">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>80</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_2">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>20</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Checkbox" name="checkbox_7">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>190</y>
+          <width>101</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Check All</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_1">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>340</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 1</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_2">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>340</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 2</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_3">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>400</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 3</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_4">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>400</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 4</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_5">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>460</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 5</string>
+        </property>
+       </widget>
+       <widget class="Element::Radio" name="radio_6">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>460</y>
+          <width>91</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Option 6</string>
+        </property>
+       </widget>
+       <widget class="Element::RadioGroup" name="radioGroup">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>510</y>
+          <width>331</width>
+          <height>61</height>
+         </rect>
+        </property>
+        <property name="title">
+         <string>GroupBox</string>
+        </property>
+        <widget class="Element::Radio" name="radio_7">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>20</y>
+           <width>91</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Option 7</string>
+         </property>
+        </widget>
+        <widget class="Element::Radio" name="radio_8">
+         <property name="geometry">
+          <rect>
+           <x>120</x>
+           <y>20</y>
+           <width>91</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Option 8</string>
+         </property>
+        </widget>
+        <widget class="Element::Radio" name="radio_9">
+         <property name="geometry">
+          <rect>
+           <x>220</x>
+           <y>20</y>
+           <width>91</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Option 9</string>
+         </property>
+        </widget>
+       </widget>
+       <widget class="Element::CheckboxGroup" name="checkboxGroup">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>230</y>
+          <width>341</width>
+          <height>61</height>
+         </rect>
+        </property>
+        <property name="title">
+         <string>GroupBox</string>
+        </property>
+        <widget class="Element::Checkbox" name="checkbox_8">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>20</y>
+           <width>91</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Beijing</string>
+         </property>
+        </widget>
+        <widget class="Element::Checkbox" name="checkbox_9">
+         <property name="geometry">
+          <rect>
+           <x>110</x>
+           <y>20</y>
+           <width>101</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Shanghai</string>
+         </property>
+        </widget>
+        <widget class="Element::Checkbox" name="checkbox_10">
+         <property name="geometry">
+          <rect>
+           <x>230</x>
+           <y>20</y>
+           <width>111</width>
+           <height>21</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Guangzhou</string>
+         </property>
+        </widget>
+       </widget>
+       <widget class="Element::Rate" name="rate" native="true">
+        <property name="geometry">
+         <rect>
+          <x>50</x>
+          <y>610</y>
+          <width>251</width>
+          <height>51</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Menu" name="menu">
+        <property name="geometry">
+         <rect>
+          <x>470</x>
+          <y>20</y>
+          <width>181</width>
+          <height>531</height>
+         </rect>
+        </property>
+        <attribute name="headerVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+        </column>
+       </widget>
+       <widget class="Element::Stack" name="stack">
+        <property name="geometry">
+         <rect>
+          <x>660</x>
+          <y>20</y>
+          <width>461</width>
+          <height>431</height>
+         </rect>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_10">
+       <attribute name="title">
+        <string>页面</string>
+       </attribute>
+       <widget class="Element::Tabs" name="tabs">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>30</y>
+          <width>461</width>
+          <height>381</height>
+         </rect>
+        </property>
+        <property name="currentIndex">
+         <number>3</number>
+        </property>
+        <widget class="QWidget" name="tab1_tabs">
+         <attribute name="title">
+          <string>User</string>
+         </attribute>
+         <widget class="QLabel" name="label_user">
+          <property name="geometry">
+           <rect>
+            <x>40</x>
+            <y>40</y>
+            <width>121</width>
+            <height>51</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>User</string>
+          </property>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="tab2_tabs">
+         <attribute name="title">
+          <string>Config</string>
+         </attribute>
+         <widget class="QLabel" name="label_config">
+          <property name="geometry">
+           <rect>
+            <x>40</x>
+            <y>40</y>
+            <width>121</width>
+            <height>51</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>Config</string>
+          </property>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="tab3_tabs">
+         <attribute name="title">
+          <string>Role</string>
+         </attribute>
+         <widget class="QLabel" name="label_role">
+          <property name="geometry">
+           <rect>
+            <x>40</x>
+            <y>40</y>
+            <width>121</width>
+            <height>51</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>Role</string>
+          </property>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="tab4_tabs">
+         <attribute name="title">
+          <string>Task</string>
+         </attribute>
+         <widget class="QLabel" name="label_task">
+          <property name="geometry">
+           <rect>
+            <x>40</x>
+            <y>40</y>
+            <width>121</width>
+            <height>51</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>Task</string>
+          </property>
+         </widget>
+        </widget>
+       </widget>
+       <widget class="Element::Button" name="button_64">
+        <property name="geometry">
+         <rect>
+          <x>30</x>
+          <y>490</y>
+          <width>121</width>
+          <height>31</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>open drawer</string>
+        </property>
+       </widget>
+       <widget class="Element::Progress" name="progress_1" native="true">
+        <property name="geometry">
+         <rect>
+          <x>500</x>
+          <y>30</y>
+          <width>500</width>
+          <height>30</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Progress" name="progress_2" native="true">
+        <property name="geometry">
+         <rect>
+          <x>500</x>
+          <y>90</y>
+          <width>200</width>
+          <height>150</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="Element::Progress" name="progress_3" native="true">
+        <property name="geometry">
+         <rect>
+          <x>730</x>
+          <y>90</y>
+          <width>200</width>
+          <height>150</height>
+         </rect>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="tab_11">
+       <attribute name="title">
+        <string>其他</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_11">
+          <item>
+           <widget class="Element::Carousel" name="carousel" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>500</width>
+              <height>260</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>500</width>
+              <height>260</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_8">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="Element::Image" name="image" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>260</width>
+              <height>260</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>260</width>
+              <height>260</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>30</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>400</height>
+           </size>
+          </property>
+          <property name="sizeIncrement">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_3" stretch="10,1,20">
+             <item>
+              <widget class="QWidget" name="widget_1" native="true">
+               <property name="minimumSize">
+                <size>
+                 <width>500</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="styleSheet">
+                <string notr="true"/>
+               </property>
+               <widget class="QLabel" name="dividerText_1">
+                <property name="geometry">
+                 <rect>
+                  <x>20</x>
+                  <y>10</y>
+                  <width>491</width>
+                  <height>21</height>
+                 </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>青春是一个短暂的美梦, 当你醒来时, 它早已消失无踪</string>
+                </property>
+               </widget>
+               <widget class="QLabel" name="dividerText_2">
+                <property name="geometry">
+                 <rect>
+                  <x>20</x>
+                  <y>70</y>
+                  <width>461</width>
+                  <height>21</height>
+                 </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>少量的邪恶足以抵消全部高贵的品质, 害得人声名狼藉</string>
+                </property>
+               </widget>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_2" native="true">
+               <property name="styleSheet">
+                <string notr="true">border-color: rgb(184, 184, 184);</string>
+               </property>
+               <widget class="QLabel" name="dividerText_3">
+                <property name="geometry">
+                 <rect>
+                  <x>20</x>
+                  <y>10</y>
+                  <width>381</width>
+                  <height>21</height>
+                 </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>头上一片晴天，心中一个想念</string>
+                </property>
+               </widget>
+               <widget class="QLabel" name="dividerText_4">
+                <property name="geometry">
+                 <rect>
+                  <x>30</x>
+                  <y>80</y>
+                  <width>381</width>
+                  <height>21</height>
+                 </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>饿了别叫妈, 叫饿了么</string>
+                </property>
+               </widget>
+               <widget class="QLabel" name="dividerText_5">
+                <property name="geometry">
+                 <rect>
+                  <x>40</x>
+                  <y>140</y>
+                  <width>381</width>
+                  <height>21</height>
+                 </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>为了无法计算的价值</string>
+                </property>
+               </widget>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>70</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QWidget" name="widget_3" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>270</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>270</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <widget class="QLabel" name="dividerText_6">
+              <property name="geometry">
+               <rect>
+                <x>20</x>
+                <y>10</y>
+                <width>61</width>
+                <height>21</height>
+               </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>雨纷纷</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+             <widget class="QLabel" name="dividerText_7">
+              <property name="geometry">
+               <rect>
+                <x>80</x>
+                <y>10</y>
+                <width>61</width>
+                <height>21</height>
+               </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>旧故里</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+             <widget class="QLabel" name="dividerText_8">
+              <property name="geometry">
+               <rect>
+                <x>140</x>
+                <y>10</y>
+                <width>61</width>
+                <height>21</height>
+               </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>草木深</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
      </widget>
-    </widget>
-   </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <customwidgets>


### PR DESCRIPTION
### 一. 实现Animation类
- 为控件提供静态动画方法，包含一些原子动画和组合动画
- 原子动画：平移、透明度变化（淡入/淡出）
- 组合动画：平移+淡入、平移+淡出、收缩+淡出

---
### 二. 控件及其修改说明
1. Mask：为covered也安装事件过滤器；  

2. Dialog：在中添加事件监听：当父窗口Move或Resize，更新自身位置，从而实现跟随效果，原动画实现改为调用Animation静态方法，所属遮罩也添加淡入/淡出动画，过渡更自然，修改了信号和回调函数的触发时机（具体参考Drawer修改）；  
3. Message：原动画实现改为调用Animation静态方法；  
4. Tag：更改tag的关闭按钮光标为pointinghand，为其添加关闭动画，可通过setDisableTransitions方法禁用/启用该属性。
5. Drawer：添加了出现和消失动画，监听父窗口resize事件，使其大小、位置随父窗口改变；添加opened、accepted、rejected和closed信号，将按键点击和控件关闭解绑，按键点击只发射对应信号；提供关闭方法，以便关闭时机由使用者决定；完成before-open和before-close的回调功能，时机分别为Drawer打开前和Drawer关闭前。
#### 效果图如下：
<img width="1281" height="837" alt="tag" src="https://github.com/user-attachments/assets/88f9efde-5681-4a8d-847e-c1c6439b4ac5" />

---

<img width="1920" height="1080" alt="drawer" src="https://github.com/user-attachments/assets/56aa4b47-9005-4e3b-9e0c-0815036be192" />
