### PR TITLE
<FIX>(Tag): 改进关闭动画和修复动画期间布局压缩问题

### DIFF
--- a/components/dialog.cpp
+++ b/components/dialog.cpp
@@ -137,7 +137,7 @@ namespace Element
                 connect(_mask, &Mask::clicked, this, [this]() { closeDialog(false); });
             }
 
-            Animation::fadeIn(_mask, Animation::Type::GraphicsEffect, 300);
+            Animation::fadeIn(_mask, Animation::OpacityType::GraphicsEffect, 300);
 
             QEventLoop loop;
             connect(this, &QDialog::finished, &loop, &QEventLoop::quit);
@@ -171,14 +171,14 @@ namespace Element
         if (_beforeOpenCallback)
         {
             _beforeOpenCallback([this]() {
-                Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300, [this](){
+                Animation::fadeInMove(this, Animation::OpacityType::WindowOpacity, -20, 300, [this](){
                     emit opened();
                 });
             });
         }
         else
         {
-            Animation::fadeInMove(this, Animation::Type::WindowOpacity, -20, 300, [this](){
+            Animation::fadeInMove(this, Animation::OpacityType::WindowOpacity, -20, 300, [this](){
                 emit opened();
             });
         }
@@ -238,10 +238,10 @@ namespace Element
         if(_mask && _modal)
         {
             _mask->setDisabled(true);
-            Animation::fadeOut(_mask, Animation::Type::GraphicsEffect, 300);
+            Animation::fadeOut(_mask, Animation::OpacityType::GraphicsEffect, 300);
         }
 
-        Animation::fadeOutMove(this, Animation::Type::WindowOpacity, -20, 300, [this]() {
+        Animation::fadeOutMove(this, Animation::OpacityType::WindowOpacity, -20, 300, [this]() {
             emit closed();
             QDialog::close();
         });

--- a/components/drawer.cpp
+++ b/components/drawer.cpp
@@ -170,7 +170,7 @@ namespace Element
         if(_modal)
         {
             _mask->setDisabled(true);
-            Animation::fadeIn(_mask, Animation::Type::GraphicsEffect, 300, [this](){
+            Animation::fadeIn(_mask, Animation::OpacityType::GraphicsEffect, 300, [this](){
                 _mask->setDisabled(false);
             });
         }
@@ -191,7 +191,7 @@ namespace Element
         if(_modal)
         {
             _mask->setDisabled(true);
-            Animation::fadeOut(_mask, Animation::Type::GraphicsEffect, 300, [this](){
+            Animation::fadeOut(_mask, Animation::OpacityType::GraphicsEffect, 300, [this](){
                 _mask->setDisabled(false);
             });
         }

--- a/components/message.cpp
+++ b/components/message.cpp
@@ -176,7 +176,7 @@ namespace Element
 
         QWidget::show();
 
-        _fadeInAnim = Animation::fadeInMove(this, Animation::Type::GraphicsEffect, offset, 300);
+        _fadeInAnim = Animation::fadeInMove(this, Animation::OpacityType::GraphicsEffect, offset, 300);
     }
 
     QString Message::getColor()
@@ -255,7 +255,7 @@ namespace Element
             break;
         }
 
-        Animation::fadeOutMove(this, Animation::Type::GraphicsEffect, offset, 300, [this]() {
+        Animation::fadeOutMove(this, Animation::OpacityType::GraphicsEffect, offset, 300, [this]() {
             if(_onClose)
                 emit close();
 

--- a/components/private/animation.cpp
+++ b/components/private/animation.cpp
@@ -18,10 +18,10 @@ namespace Element
         return curve;
     }
 
-    QParallelAnimationGroup* Animation::XShrinkFadeOut(QWidget* widget, int duration,
+    QParallelAnimationGroup* Animation::shrinkFadeOut(QWidget* widget, Direction dir, int duration,
                                   std::function<void()> onFinished)
     {
-        QPropertyAnimation* scaleAnim = getScaleAnim(widget, X, {1.0, 0.0}, duration);
+        QPropertyAnimation* scaleAnim = getScaleAnim(widget, dir, {1.0, 0.0}, duration);
         QPropertyAnimation* opacityAnim = getOpaAnim(widget, OpacityType::GraphicsEffect, {1.0, 0.0}, duration);
 
         QParallelAnimationGroup* group = new QParallelAnimationGroup;
@@ -142,7 +142,7 @@ namespace Element
         return curve;
     }
 
-    QPropertyAnimation* Animation::getOpaAnim(QWidget* widget, Element::Animation::OpacityType type,
+    QPropertyAnimation* Animation::getOpaAnim(QWidget* widget, OpacityType type,
                                               OpacityRange opacity, int duration)
     {
         QPropertyAnimation* anim = nullptr;
@@ -172,10 +172,10 @@ namespace Element
         return anim;
     }
 
-    QPropertyAnimation* Animation::getScaleAnim(QWidget* widget, Element::Animation::ScaleType type, ScaleRange scale, int duration)
+    QPropertyAnimation* Animation::getScaleAnim(QWidget* widget, Direction dir, ScaleRange scale, int duration)
     {
         QPropertyAnimation* scaleAnim = nullptr;
-        if(type == ScaleType::X)
+        if(dir == Direction::Horizontal)
             scaleAnim = new QPropertyAnimation(widget, "xScale");
         else
             scaleAnim = new QPropertyAnimation(widget, "yScale");

--- a/components/private/animation.cpp
+++ b/components/private/animation.cpp
@@ -2,6 +2,11 @@
 
 #include <QGraphicsOpacityEffect>
 #include <QLayout>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QGraphicsProxyWidget>
+#include <QGraphicsRotation>
+#include <QLayout>
 
 namespace Element
 {
@@ -13,60 +18,39 @@ namespace Element
         return curve;
     }
 
-    QParallelAnimationGroup* Animation::horShrinkFadeOut(QWidget* widget, Type type,
-                                        int duration, std::function<void()> onFinished)
+    QParallelAnimationGroup* Animation::XShrinkFadeOut(QWidget* widget, int duration,
+                                  std::function<void()> onFinished)
     {
-        const auto allChildren = widget->findChildren<QWidget*>();
-
-        for (QWidget* child : allChildren)
-        {
-            child->setMinimumWidth(0);
-            QSizePolicy policy = child->sizePolicy();
-            policy.setHorizontalPolicy(QSizePolicy::Ignored);
-            child->setSizePolicy(policy);
-        }
-
-        widget->setMinimumWidth(0);
-        QSizePolicy policy = widget->sizePolicy();
-        policy.setHorizontalPolicy(QSizePolicy::Ignored);
-        widget->setSizePolicy(policy);
+        QPropertyAnimation* scaleAnim = getScaleAnim(widget, X, {1.0, 0.0}, duration);
+        QPropertyAnimation* opacityAnim = getOpaAnim(widget, OpacityType::GraphicsEffect, {1.0, 0.0}, duration);
 
         QParallelAnimationGroup* group = new QParallelAnimationGroup;
-        group->addAnimation(getOpaAnim(widget, type, 1.0, 0.0, duration));
-
-        QRect startRect = widget->geometry();
-        int centerX = startRect.x() + startRect.width() / 2;
-        QRect endRect(centerX, startRect.y(), 0, startRect.height());
-
-        QPropertyAnimation* shrAnim = new QPropertyAnimation(widget, "geometry");
-        shrAnim->setDuration(duration);
-        shrAnim->setStartValue(startRect);
-        shrAnim->setEndValue(endRect);
-        shrAnim->setEasingCurve(easingCurve());
-        group->addAnimation(shrAnim);
+        group->addAnimation(scaleAnim);
+        group->addAnimation(opacityAnim);
 
         if (onFinished)
         {
-            QObject::connect(group, &QPropertyAnimation::finished, onFinished);
+            QObject::connect(group, &QParallelAnimationGroup::finished, onFinished);
         }
-        QObject::connect(group, &QPropertyAnimation::finished, group, &QObject::deleteLater);
+        QObject::connect(group, &QParallelAnimationGroup::finished,
+                         group, &QObject::deleteLater);
         group->start();
         return group;
     }
 
-    QPropertyAnimation* Animation::fadeIn(QWidget* widget, Type type, int duration,
+    QPropertyAnimation* Animation::fadeIn(QWidget* widget, OpacityType type, int duration,
                            std::function<void()> onFinished)
     {
         return fade(widget, {0.0, 1.0}, type, duration, onFinished);
     }
 
-    QPropertyAnimation* Animation::fadeOut(QWidget* widget, Type type, int duration,
+    QPropertyAnimation* Animation::fadeOut(QWidget* widget, OpacityType type, int duration,
                             std::function<void()> onFinished)
     {
         return fade(widget, {1.0, 0.0}, type, duration, onFinished);
     }
 
-    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, Type type,
+    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, OpacityType type,
                                   int offset, int duration, std::function<void()> onFinished)
     {
         QRect curRect = widget->geometry();
@@ -75,13 +59,13 @@ namespace Element
         return fadeMove(widget, {startRect, widget->geometry()}, {0.0, 1.0}, type, duration, onFinished);
     }
 
-    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, Type type,
+    QParallelAnimationGroup* Animation::fadeInMove(QWidget* widget, OpacityType type,
                               QRect startRect, int duration, std::function<void()> onFinished)
     {
         return fadeMove(widget, {startRect, widget->geometry()}, {0.0, 1.0}, type, duration, onFinished);
     }
 
-    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, Type type,
+    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, OpacityType type,
                                    int offset, int duration, std::function<void()> onFinished)
     {
         QRect curRect = widget->geometry();
@@ -90,16 +74,16 @@ namespace Element
         return fadeMove(widget, {widget->geometry(), endRect}, {1.0, 0.0}, type, duration, onFinished);
     }
 
-    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, Type type,
+    QParallelAnimationGroup* Animation::fadeOutMove(QWidget* widget, OpacityType type,
                         QRect endRect, int duration, std::function<void()> onFinished)
     {
         return fadeMove(widget, {widget->geometry(), endRect}, {1.0, 0.0}, type, duration, onFinished);
     }
 
-    QPropertyAnimation* Animation::fade(QWidget* widget, OpacityRange opacity,Type type,
+    QPropertyAnimation* Animation::fade(QWidget* widget, OpacityRange opacity,OpacityType type,
                          int duration, std::function<void()> onFinished)
     {
-        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, opacity.first, opacity.second, duration);
+        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, {opacity.first, opacity.second}, duration);
 
         if (onFinished)
         {
@@ -130,7 +114,7 @@ namespace Element
     }
 
     QParallelAnimationGroup* Animation::fadeMove(QWidget* widget, RectRange geometry, OpacityRange opacity,
-                         Type type, int duration, std::function<void()> onFinished)
+                         OpacityType type, int duration, std::function<void()> onFinished)
     {
         QParallelAnimationGroup* group = new QParallelAnimationGroup;
         QPropertyAnimation* moveAnim = new QPropertyAnimation(widget, "geometry");
@@ -140,7 +124,7 @@ namespace Element
         moveAnim->setEndValue(geometry.second);
         group->addAnimation(moveAnim);
 
-        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, opacity.first, opacity.second, duration);
+        QPropertyAnimation* opaAnim = getOpaAnim(widget, type, {opacity.first, opacity.second}, duration);
         group->addAnimation(opaAnim);
 
         if (onFinished)
@@ -158,13 +142,13 @@ namespace Element
         return curve;
     }
 
-    QPropertyAnimation* Animation::getOpaAnim(QWidget* widget, Element::Animation::Type type,
-                                              double startVal, double endVal, int duration)
+    QPropertyAnimation* Animation::getOpaAnim(QWidget* widget, Element::Animation::OpacityType type,
+                                              OpacityRange opacity, int duration)
     {
         QPropertyAnimation* anim = nullptr;
-        if (type == Element::Animation::Type::WindowOpacity)
+        if (type == Element::Animation::OpacityType::WindowOpacity)
         {
-            widget->setWindowOpacity(startVal);
+            widget->setWindowOpacity(opacity.first);
             anim = new QPropertyAnimation(widget, "windowOpacity");
         }
         else
@@ -175,16 +159,31 @@ namespace Element
                 effect = new QGraphicsOpacityEffect(widget);
                 widget->setGraphicsEffect(effect);
             }
-            effect->setOpacity(startVal);
+            effect->setOpacity(opacity.first);
             anim = new QPropertyAnimation(effect, "opacity");
         }
         if(anim)
         {
-            anim->setStartValue(startVal);
-            anim->setEndValue(endVal);
+            anim->setStartValue(opacity.first);
+            anim->setEndValue(opacity.second);
             anim->setDuration(duration);
             anim->setEasingCurve(easingCurve());
         }
         return anim;
+    }
+
+    QPropertyAnimation* Animation::getScaleAnim(QWidget* widget, Element::Animation::ScaleType type, ScaleRange scale, int duration)
+    {
+        QPropertyAnimation* scaleAnim = nullptr;
+        if(type == ScaleType::X)
+            scaleAnim = new QPropertyAnimation(widget, "xScale");
+        else
+            scaleAnim = new QPropertyAnimation(widget, "yScale");
+
+        scaleAnim->setDuration(duration);
+        scaleAnim->setStartValue(scale.first);
+        scaleAnim->setEndValue(scale.second);
+        scaleAnim->setEasingCurve(easingCurve());
+        return scaleAnim;
     }
 }

--- a/components/private/animation.h
+++ b/components/private/animation.h
@@ -18,9 +18,9 @@ namespace Element
 
         enum OpacityType {   WindowOpacity, GraphicsEffect  };
 
-        enum ScaleType {    X, Y    };
+        enum Direction {    Horizontal, Vertical    };
 
-        static QParallelAnimationGroup* XShrinkFadeOut(QWidget* widget, int duration = 300,
+        static QParallelAnimationGroup* shrinkFadeOut(QWidget* widget, Direction dir, int duration = 300,
                                   std::function<void()> onFinished = nullptr);
 
         static QPropertyAnimation* fadeIn(QWidget* widget, OpacityType type, int duration = 300,
@@ -58,9 +58,9 @@ namespace Element
                              OpacityRange opacity, OpacityType type,
                              int duration, std::function<void()> onFinished = nullptr);
 
-        static QPropertyAnimation* getOpaAnim(QWidget* widget, Element::Animation::OpacityType type, OpacityRange opacity, int duration);
+        static QPropertyAnimation* getOpaAnim(QWidget* widget, OpacityType type, OpacityRange opacity, int duration);
 
-        static QPropertyAnimation* getScaleAnim(QWidget* widget, Element::Animation::ScaleType type, ScaleRange scale, int duration);
+        static QPropertyAnimation* getScaleAnim(QWidget* widget, Direction dir, ScaleRange scale, int duration);
 
         static const QEasingCurve& easingCurve();
     };

--- a/components/private/animation.h
+++ b/components/private/animation.h
@@ -14,50 +14,54 @@ namespace Element
         // pair<Start_Value, End_Value>
         using RectRange = std::pair<QRect, QRect>;
         using OpacityRange = std::pair<double, double>;
+        using ScaleRange = std::pair<double, double>;
 
-        enum class Type {   WindowOpacity, GraphicsEffect  };
+        enum OpacityType {   WindowOpacity, GraphicsEffect  };
 
-        static QParallelAnimationGroup* horShrinkFadeOut(QWidget* widget, Type type, int duration = 200,
-                                          std::function<void()> onFinished = nullptr);
+        enum ScaleType {    X, Y    };
 
-        static QPropertyAnimation* fadeIn(QWidget* widget, Type type, int duration = 300,
+        static QParallelAnimationGroup* XShrinkFadeOut(QWidget* widget, int duration = 300,
+                                  std::function<void()> onFinished = nullptr);
+
+        static QPropertyAnimation* fadeIn(QWidget* widget, OpacityType type, int duration = 300,
                            std::function<void()> onFinished = nullptr);
 
-        static QPropertyAnimation* fadeOut(QWidget* widget, Type type, int duration = 300,
+        static QPropertyAnimation* fadeOut(QWidget* widget, OpacityType type, int duration = 300,
                             std::function<void()> onFinished = nullptr);
 
         // The default transition direction is top‑down.
-        static QParallelAnimationGroup* fadeInMove(QWidget* widget, Type type,
+        static QParallelAnimationGroup* fadeInMove(QWidget* widget, OpacityType type,
                                   int offset = 20, int duration = 300,
                                   std::function<void()> onFinished = nullptr);
 
-        static QParallelAnimationGroup* fadeInMove(QWidget* widget, Type type,
+        static QParallelAnimationGroup* fadeInMove(QWidget* widget, OpacityType type,
                                   QRect startRect, int duration = 300,
                                   std::function<void()> onFinished = nullptr);
 
         // The default transition direction is down-top.
-        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, Type type,
+        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, OpacityType type,
                                    int offset = 20, int duration = 300,
                                    std::function<void()> onFinished = nullptr);
 
-        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, Type type,
+        static QParallelAnimationGroup* fadeOutMove(QWidget* widget, OpacityType type,
                                    QRect endRect, int duration = 300,
                                    std::function<void()> onFinished = nullptr);
 
         static QPropertyAnimation* fade(QWidget* widget, OpacityRange opacity,
-                         Type type, int duration,
+                         OpacityType type, int duration,
                          std::function<void()> onFinished = nullptr);
 
         static QPropertyAnimation* move(QWidget* widget, const QRect& targetRect, int duration = 300,
                          std::function<void()> onFinished = nullptr);
 
         static QParallelAnimationGroup* fadeMove(QWidget* widget, RectRange geometry,
-                             OpacityRange opacity, Type type,
+                             OpacityRange opacity, OpacityType type,
                              int duration, std::function<void()> onFinished = nullptr);
 
-    private:
-        static const QEasingCurve& easingCurve();
+        static QPropertyAnimation* getOpaAnim(QWidget* widget, Element::Animation::OpacityType type, OpacityRange opacity, int duration);
 
-        static QPropertyAnimation* getOpaAnim(QWidget* widget, Element::Animation::Type type, double startVal, double endVal, int duration);
+        static QPropertyAnimation* getScaleAnim(QWidget* widget, Element::Animation::ScaleType type, ScaleRange scale, int duration);
+
+        static const QEasingCurve& easingCurve();
     };
 }

--- a/components/tag.cpp
+++ b/components/tag.cpp
@@ -1,12 +1,15 @@
 #include "tag.h"
-
 #include "color.h"
 #include "icon.h"
 #include "private/utils.h"
 #include "private/animation.h"
 
-#include <QEvent>
-
+#include <QPainter>
+#include <QMouseEvent>
+#include <QFontMetrics>
+#include <QPropertyAnimation>
+#include <QGraphicsOpacityEffect>
+#include <QPainterPath>
 
 namespace Element
 {
@@ -18,134 +21,113 @@ namespace Element
     {}
 
     Tag::Tag(const QString& text, Type type, QWidget* parent)
-        : QLabel(parent)
+        : QWidget(parent)
+        , _text(text)
         , _type(type)
-        , _textLabel(new QLabel(text, this))
-        , _closeIcon(new QLabel(this))
-        , _layout(new QHBoxLayout(this))
     {
-        _disTrans = false;
-
-        _textLabel->setFont(FontHelper(_textLabel->font())
-                .setPointSize(9)
-                .getFont());
-        _textLabel->setAlignment(Qt::AlignCenter);
-
-        _closeIcon->setFixedSize(16, 16);
-        _closeIcon->setScaledContents(true);
-        _closeIcon->setVisible(false);
-        _closeIcon->setCursor(Qt::PointingHandCursor);
-        _closeIcon->installEventFilter(this);
-
-        _layout->setContentsMargins(0, 0, 0, 0);
-        _layout->setSpacing(4);
-        _layout->addWidget(_textLabel);
-        _layout->addWidget(_closeIcon);
-
-        setLayout(_layout);
-
-        setStyleSheet(_qsshelper.setProperty("QLabel", "border-radius", "4px")
-                                .setProperty("QLabel", "padding", "0px 9px")
-                                .generate());
-        adjustSize();
-        setEffect(_effect);
-        setType(_type);
-        setSize(_size);
+        setAttribute(Qt::WA_OpaquePaintEvent, false);
+        setAttribute(Qt::WA_Hover, true);
+        setMouseTracking(true);
+        setSize(Size::Default);
+        updateCachedColors();
+        setFont(FontHelper().setPointSize(9).getFont());
     }
 
     Tag& Tag::setEffect(Effect effect)
     {
+        if (_effect == effect) return *this;
+
         _effect = effect;
-        setType(_type);
+        updateCachedColors();
+        update();
         return *this;
     }
 
     Tag& Tag::setType(Type type)
     {
+        if (_type == type) return *this;
+
         _type = type;
-        setStyleSheet(_qsshelper.setProperty("QLabel", "color", getColor())
-                                .setProperty("QLabel", "background-color", getBackgroundColor())
-                                .setProperty("QLabel", "border", "1px solid " + getBorderColor())
-                                .generate());
-
-        _internalQsshelper.setProperty("QLabel", "border", "none")
-                          .setProperty("QLabel", "padding", "0px");
-        _textLabel->setStyleSheet(_internalQsshelper.generate());
-        _closeIcon->setStyleSheet(_internalQsshelper.generate());
-
-        _textLabel->adjustSize();
+        updateCachedColors();
+        update();
         return *this;
     }
 
     Tag& Tag::setSize(Size size)
     {
         _size = size;
-        if (_size == Size::Default)    setFixedHeight(30), setMinimumWidth(60);
-        else if (_size == Size::Large) setFixedHeight(40), setMinimumWidth(70);
-        else if (_size == Size::Small) setFixedHeight(25), setMinimumWidth(50);
+        if (_size == Size::Default)
+            setFixedHeight(30), setMinimumWidth(60);
+        else if (_size == Size::Small)
+            setFixedHeight(25), setMinimumWidth(50);
+        else if (_size == Size::Large)
+            setFixedHeight(40), setMinimumWidth(70);
+        adjustSize();
         return *this;
     }
 
     Tag& Tag::setCloseable(bool closeable)
     {
         _closeable = closeable;
-        _closeIcon->setPixmap(Icon::instance().getPixmap(Icon::Close, getColor(), 16));
-        _closeIcon->setVisible(closeable);
+        update();
         return *this;
     }
 
     Tag& Tag::setRound(bool round)
     {
+        if (_round == round) return *this;
         _round = round;
-        if (_round)
-            setStyleSheet(_qsshelper.setProperty("QLabel", "border-radius", "15px")
-                                    .generate());
-        else
-            setStyleSheet(_qsshelper.setProperty("QLabel", "border-radius", "4px")
-                                    .generate());
+        update();
         return *this;
     }
 
-    Tag& Tag::setDisableTransitions(bool distrans)
+    Tag& Tag::setDisableTransitions(bool disabled)
     {
-        _disTrans = distrans;
+        _disTrans = disabled;
         return *this;
     }
 
     Tag& Tag::setText(const QString& text)
     {
-        _textLabel->setText(text);
+        _text = text;
+        update();
         return *this;
     }
 
-    bool Tag::eventFilter(QObject* obj, QEvent* event)
+    void Tag::startClose()
     {
-        if (obj == _closeIcon && _closeable)
+        if (_disTrans)
         {
-            if (event->type() == QEvent::MouseButtonPress)
-            {
-                if(!_disTrans)
-                {
-                    Animation::horShrinkFadeOut(this, Animation::Type::GraphicsEffect, 300, [this](){
-                        this->deleteLater();
-                    });
-                }
-                else
-                {
-                    this->deleteLater();
-                }
-                return true;
-            }
-            else if (event->type() == QEvent::Enter)
-            {
-                _closeIcon->setPixmap(Icon::instance().getPixmap(Icon::CircleCloseFilled, getColor(), 16));
-            }
-            else if (event->type() == QEvent::Leave)
-            {
-                _closeIcon->setPixmap(Icon::instance().getPixmap(Icon::Close, getColor(), 16));
-            }
+            deleteLater();
+            return;
         }
-        return QWidget::eventFilter(obj, event);
+
+        Animation::XShrinkFadeOut(this, 300, [this](){
+            emit closed();
+            this->deleteLater();
+        });
+    }
+
+    double Tag::xScale() const
+    {
+        return _xScale;
+    }
+
+    void Tag::setXScale(double scale)
+    {
+        _xScale = scale;
+        update();
+    }
+
+    double Tag::opacity() const
+    {
+        return _opacity;
+    }
+
+    void Tag::setOpacity(double opa)
+    {
+        _opacity = opa;
+        update();
     }
 
     QString Tag::getColor()
@@ -155,11 +137,11 @@ namespace Element
         case Effect::Light:
         case Effect::Plain:
             switch (_type) {
-                case Type::Primary: return Color::primary();
-                case Type::Success: return Color::success();
-                case Type::Warning: return Color::warning();
-                case Type::Info:    return Color::info();
-                case Type::Danger:  return Color::danger();
+            case Type::Primary: return Color::primary();
+            case Type::Success: return Color::success();
+            case Type::Warning: return Color::warning();
+            case Type::Info:    return Color::info();
+            case Type::Danger:  return Color::danger();
             }
         case Effect::Dark:
             return Color::basicWhite();
@@ -174,27 +156,27 @@ namespace Element
         {
         case Effect::Light:
             switch (_type) {
-                case Type::Primary: return Color::primaryL4();
-                case Type::Success: return Color::successL4();
-                case Type::Warning: return Color::warningL4();
-                case Type::Info:    return Color::infoL4();
-                case Type::Danger:  return Color::dangerL4();
+            case Type::Primary: return Color::primaryL4();
+            case Type::Success: return Color::successL4();
+            case Type::Warning: return Color::warningL4();
+            case Type::Info:    return Color::infoL4();
+            case Type::Danger:  return Color::dangerL4();
             }
         case Effect::Plain:
             switch (_type) {
-                case Type::Primary: return Color::primaryL2();
-                case Type::Success: return Color::successL2();
-                case Type::Warning: return Color::warningL2();
-                case Type::Info:    return Color::infoL2();
-                case Type::Danger:  return Color::dangerL2();
+            case Type::Primary: return Color::primaryL2();
+            case Type::Success: return Color::successL2();
+            case Type::Warning: return Color::warningL2();
+            case Type::Info:    return Color::infoL2();
+            case Type::Danger:  return Color::dangerL2();
             }
         case Effect::Dark:
             switch (_type) {
-                case Type::Primary: return Color::primary();
-                case Type::Success: return Color::success();
-                case Type::Warning: return Color::warning();
-                case Type::Info:    return Color::info();
-                case Type::Danger:  return Color::danger();
+            case Type::Primary: return Color::primary();
+            case Type::Success: return Color::success();
+            case Type::Warning: return Color::warning();
+            case Type::Info:    return Color::info();
+            case Type::Danger:  return Color::danger();
             }
         }
         return "#000000";
@@ -206,24 +188,129 @@ namespace Element
         {
         case Effect::Light:
             switch (_type) {
-                case Type::Primary: return Color::primaryL5();
-                case Type::Success: return Color::successL5();
-                case Type::Warning: return Color::warningL5();
-                case Type::Info:    return Color::infoL5();
-                case Type::Danger:  return Color::dangerL5();
+            case Type::Primary: return Color::primaryL5();
+            case Type::Success: return Color::successL5();
+            case Type::Warning: return Color::warningL5();
+            case Type::Info:    return Color::infoL5();
+            case Type::Danger:  return Color::dangerL5();
             }
         case Effect::Dark:
             switch (_type) {
-                case Type::Primary: return Color::primary();
-                case Type::Success: return Color::success();
-                case Type::Warning: return Color::warning();
-                case Type::Info:    return Color::info();
-                case Type::Danger:  return Color::danger();
+            case Type::Primary: return Color::primary();
+            case Type::Success: return Color::success();
+            case Type::Warning: return Color::warning();
+            case Type::Info:    return Color::info();
+            case Type::Danger:  return Color::danger();
             }
         case Effect::Plain:
-               return Color::basicWhite();
+            return Color::basicWhite();
         }
         return "#000000";
     }
 
+    void Tag::paintEvent(QPaintEvent*)
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing);
+
+        painter.save();
+        painter.translate(width() / 2.0, height() / 2.0);
+        painter.scale(_xScale, 1.0);
+        painter.translate(-width() / 2.0, -height() / 2.0);
+        painter.setOpacity(_opacity);
+
+        int radius = _round ? height() / 2 : 4;
+        QPainterPath path;
+        path.addRoundedRect(rect(), radius, radius);
+        painter.fillPath(path, QColor(_bgColor));
+        QPen pen(QColor(_borderColor), 1);
+        painter.setPen(pen);
+        painter.drawRoundedRect(rect(), radius, radius);
+
+        QFontMetrics fm(font());
+        int textWidth = fm.horizontalAdvance(_text);
+        int iconSize = _closeable ? 16 : 0;
+        int spacing = _closeable ? 4 : 0;
+        int startX = (width() - (textWidth + iconSize + spacing)) / 2;
+
+        QRect textRect(startX, 0, textWidth, height());
+        painter.setPen(_textColor);
+        painter.drawText(textRect, Qt::AlignVCenter, _text);
+
+        if (_closeable)
+        {
+            int iconX = startX + textWidth + spacing;
+            int iconY = (height() - iconSize) / 2;
+            QRect iconRect(iconX, iconY, iconSize, iconSize);
+            QPixmap pixmap = _closeHover ?
+                                 Icon::instance().getPixmap(Icon::CircleCloseFilled, _textColor, iconSize) :
+                                 Icon::instance().getPixmap(Icon::Close, _textColor, iconSize);
+            painter.drawPixmap(iconRect, pixmap);
+        }
+
+        painter.restore();
+    }
+
+    void Tag::mouseMoveEvent(QMouseEvent* event)
+    {
+        if (_closeable)
+        {
+            bool newHover = closeIconRect().contains(event->pos());
+            if (newHover != _closeHover)
+            {
+                _closeHover = newHover;
+                setCursor(_closeHover ? Qt::PointingHandCursor : Qt::ArrowCursor);
+                update();
+            }
+        }
+        QWidget::mouseMoveEvent(event);
+    }
+
+    void Tag::mouseReleaseEvent(QMouseEvent* event)
+    {
+        if (_closeable && closeIconRect().contains(event->pos()))
+        {
+            startClose();
+            event->accept();
+            return;
+        }
+        QWidget::mouseReleaseEvent(event);
+    }
+
+    void Tag::enterEvent(QEvent* event)
+    {
+        _hover = true;
+        update();
+        QWidget::enterEvent(event);
+    }
+
+    void Tag::leaveEvent(QEvent* event)
+    {
+        if (_closeable)
+        {
+            _closeHover = false;
+            setCursor(Qt::ArrowCursor);
+            update();
+        }
+        QWidget::leaveEvent(event);
+    }
+
+    QRect Tag::closeIconRect()
+    {
+        if (!_closeable) return QRect();
+        QFontMetrics fm(font());
+        int textWidth = fm.horizontalAdvance(_text);
+        int iconSize = 16;
+        int startX = (width() - (textWidth + iconSize + 4)) / 2;
+        int iconX = startX + textWidth + 4;
+        int iconY = (height() - iconSize) / 2;
+        return QRect(iconX, iconY, iconSize, iconSize);
+    }
+
+    void Tag::updateCachedColors()
+    {
+        _textColor = getColor();
+        _borderColor = getBorderColor();
+        _bgColor = getBackgroundColor();
+    }
 }

--- a/components/tag.cpp
+++ b/components/tag.cpp
@@ -102,7 +102,7 @@ namespace Element
             return;
         }
 
-        Animation::XShrinkFadeOut(this, 300, [this](){
+        Animation::shrinkFadeOut(this, Animation::Direction::Horizontal, 300, [this](){
             emit closed();
             this->deleteLater();
         });

--- a/components/tag.h
+++ b/components/tag.h
@@ -1,15 +1,28 @@
 #pragma once
 
-#include "private/utils.h"
+#include <QWidget>
+#include <QFont>
+#include <QPointer>
+#include <QPropertyAnimation>
 
-#include <QLabel>
-#include <QBoxLayout>
+namespace Element {
 
-namespace Element
-{
-    class Tag : public QLabel
+    /* Note:
+     * To prevent font‑rendering errors (e.g., QWinFontEngine: unable to query transformed glyph metrics)
+     * when the Tag's animation triggers a scaled text effect on Windows,
+     * you must set the following environment variable before constructing your QApplication instance:
+     *
+     *     qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
+     *
+     * Failure to do so may result in console warnings, visual glitches, or incomplete animations.
+     * This setting forces Qt to use the FreeType font engine, which correctly handles transformed text.
+     */
+
+    class Tag : public QWidget
     {
-    Q_OBJECT
+        Q_OBJECT
+        Q_PROPERTY(double xScale READ xScale WRITE setXScale)
+        Q_PROPERTY(double opacity READ opacity WRITE setOpacity)
 
     public:
         enum class Effect
@@ -36,43 +49,59 @@ namespace Element
         };
 
     public:
-        Tag& setEffect(Effect effect);
-        Tag& setType(Type type);
-        Tag& setSize(Size size);
-
-        Tag& setCloseable(bool closeable);
-        Tag& setRound(bool round);
-        Tag& setDisableTransitions(bool distrans);
-
-        Tag& setText(const QString& text);
-
-    public:
         Tag(QWidget* parent = nullptr);
         Tag(const QString& text, QWidget* parent = nullptr);
         Tag(const QString& text, Type type, QWidget* parent = nullptr);
+
+    public:
+        Tag& setEffect(Effect effect);
+        Tag& setType(Type type);
+        Tag& setSize(Size size);
+        Tag& setCloseable(bool closeable);
+        Tag& setRound(bool round);
+        Tag& setDisableTransitions(bool disabled);
+        Tag& setText(const QString& text);
+
+        void startClose();
+
+        double xScale() const;
+        void setXScale(double scalse);
+        double opacity() const;
+        void setOpacity(double opa);
+
+    signals:
+        void closed();
+
+    protected:
+        void paintEvent(QPaintEvent* event) override;
+        void mouseMoveEvent(QMouseEvent* event) override;
+        void mouseReleaseEvent(QMouseEvent* event) override;
+        void enterEvent(QEvent* event) override;
+        void leaveEvent(QEvent* event) override;
 
     private:
         QString getColor();
         QString getBorderColor();
         QString getBackgroundColor();
-
-        bool eventFilter(QObject* obj, QEvent* event);
+        QRect closeIconRect();
+        void updateCachedColors();
 
     private:
-        Effect _effect = Effect::Light;
+        bool _round = false;
+        bool _closeable = false;
+        bool _disTrans = false;
+        bool _hover = false;
+        bool _closeHover = false;
+        double _xScale = 1.0;
+        double _opacity = 1.0;
         Type _type = Type::Info;
+        Effect _effect = Effect::Light;
         Size _size = Size::Default;
 
-        bool _closeable;
-        bool _round;
-        bool _disTrans;
-
-        QLabel* _textLabel = nullptr;
-        QLabel* _closeIcon = nullptr;
-        QHBoxLayout* _layout = nullptr;
-
-    private:
-        QSSHelper _qsshelper;
-        QSSHelper _internalQsshelper;
+        QString _text;
+        QString _textColor;
+        QString _borderColor;
+        QString _bgColor;
     };
+
 }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -474,35 +474,35 @@ void Example::setupTab6()
     Badge* badge = new Badge(ui->avatar);
     badge->setValue(1);
 
-    ui->tag_01->setType(Tag::Type::Primary);
-    ui->tag_02->setType(Tag::Type::Success);
-    ui->tag_03->setType(Tag::Type::Info);
-    ui->tag_04->setType(Tag::Type::Warning);
-    ui->tag_05->setType(Tag::Type::Danger);
+    ui->tag_01->setType(Tag::Type::Primary).setText("Tag 1");
+    ui->tag_02->setType(Tag::Type::Success).setText("Tag 2");
+    ui->tag_03->setType(Tag::Type::Info).setText("Tag 3");
+    ui->tag_04->setType(Tag::Type::Warning).setText("Tag 4");
+    ui->tag_05->setType(Tag::Type::Danger).setText("Tag 5");
 
-    ui->tag_06->setType(Tag::Type::Primary).setEffect(Tag::Effect::Dark);
-    ui->tag_07->setType(Tag::Type::Success).setEffect(Tag::Effect::Dark);
-    ui->tag_08->setType(Tag::Type::Info).setEffect(Tag::Effect::Dark);
-    ui->tag_09->setType(Tag::Type::Warning).setEffect(Tag::Effect::Dark);
-    ui->tag_10->setType(Tag::Type::Danger).setEffect(Tag::Effect::Dark);
+    ui->tag_06->setType(Tag::Type::Primary).setEffect(Tag::Effect::Dark).setText("Tag 1");
+    ui->tag_07->setType(Tag::Type::Success).setEffect(Tag::Effect::Dark).setText("Tag 2");
+    ui->tag_08->setType(Tag::Type::Info).setEffect(Tag::Effect::Dark).setText("Tag 3");
+    ui->tag_09->setType(Tag::Type::Warning).setEffect(Tag::Effect::Dark).setText("Tag 4");
+    ui->tag_10->setType(Tag::Type::Danger).setEffect(Tag::Effect::Dark).setText("Tag 5");
 
-    ui->tag_11->setType(Tag::Type::Primary).setEffect(Tag::Effect::Plain);
-    ui->tag_12->setType(Tag::Type::Success).setEffect(Tag::Effect::Plain);
-    ui->tag_13->setType(Tag::Type::Info).setEffect(Tag::Effect::Plain);
-    ui->tag_14->setType(Tag::Type::Warning).setEffect(Tag::Effect::Plain);
-    ui->tag_15->setType(Tag::Type::Danger).setEffect(Tag::Effect::Plain);
+    ui->tag_11->setType(Tag::Type::Primary).setEffect(Tag::Effect::Plain).setText("Tag 1");
+    ui->tag_12->setType(Tag::Type::Success).setEffect(Tag::Effect::Plain).setText("Tag 2");
+    ui->tag_13->setType(Tag::Type::Info).setEffect(Tag::Effect::Plain).setText("Tag 3");
+    ui->tag_14->setType(Tag::Type::Warning).setEffect(Tag::Effect::Plain).setText("Tag 4");
+    ui->tag_15->setType(Tag::Type::Danger).setEffect(Tag::Effect::Plain).setText("Tag 5");
 
-    ui->tag_16->setType(Tag::Type::Primary).setRound(true);
-    ui->tag_17->setType(Tag::Type::Success).setRound(true);
-    ui->tag_18->setType(Tag::Type::Info).setRound(true);
-    ui->tag_19->setType(Tag::Type::Warning).setRound(true);
-    ui->tag_20->setType(Tag::Type::Danger).setRound(true);
+    ui->tag_16->setType(Tag::Type::Primary).setRound(true).setText("Tag 1");
+    ui->tag_17->setType(Tag::Type::Success).setRound(true).setText("Tag 2");
+    ui->tag_18->setType(Tag::Type::Info).setRound(true).setText("Tag 3");
+    ui->tag_19->setType(Tag::Type::Warning).setRound(true).setText("Tag 4");
+    ui->tag_20->setType(Tag::Type::Danger).setRound(true).setText("Tag 5");
 
-    ui->tag_21->setType(Tag::Type::Primary);
-    ui->tag_22->setType(Tag::Type::Success);
-    ui->tag_23->setType(Tag::Type::Info);
-    ui->tag_24->setType(Tag::Type::Warning);
-    ui->tag_25->setType(Tag::Type::Danger);
+    ui->tag_21->setType(Tag::Type::Primary).setText("Tag 1");
+    ui->tag_22->setType(Tag::Type::Success).setText("Tag 2");
+    ui->tag_23->setType(Tag::Type::Info).setText("Tag 3");
+    ui->tag_24->setType(Tag::Type::Warning).setText("Tag 4");
+    ui->tag_25->setType(Tag::Type::Danger).setText("Tag 5");
 
     ui->tag_21->setCloseable(true);
     ui->tag_22->setCloseable(true);

--- a/example/example.ui
+++ b/example/example.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>10</number>
+       <number>6</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideNone</enum>
@@ -1591,436 +1591,841 @@
        <attribute name="title">
         <string>数据</string>
        </attribute>
-       <widget class="Element::Avatar" name="avatar">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>30</y>
-          <width>80</width>
-          <height>80</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>avatar</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_01">
-        <property name="geometry">
-         <rect>
-          <x>160</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 1</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_02">
-        <property name="geometry">
-         <rect>
-          <x>230</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 2</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_03">
-        <property name="geometry">
-         <rect>
-          <x>300</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 3</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_04">
-        <property name="geometry">
-         <rect>
-          <x>370</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 4</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_05">
-        <property name="geometry">
-         <rect>
-          <x>440</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 5</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_21">
-        <property name="geometry">
-         <rect>
-          <x>160</x>
-          <y>130</y>
-          <width>81</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 1</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_22">
-        <property name="geometry">
-         <rect>
-          <x>250</x>
-          <y>130</y>
-          <width>81</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 2</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_23">
-        <property name="geometry">
-         <rect>
-          <x>340</x>
-          <y>130</y>
-          <width>81</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 3</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_24">
-        <property name="geometry">
-         <rect>
-          <x>430</x>
-          <y>130</y>
-          <width>81</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 4</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_25">
-        <property name="geometry">
-         <rect>
-          <x>520</x>
-          <y>130</y>
-          <width>81</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 5</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_06">
-        <property name="geometry">
-         <rect>
-          <x>530</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 1</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_07">
-        <property name="geometry">
-         <rect>
-          <x>600</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 2</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_08">
-        <property name="geometry">
-         <rect>
-          <x>670</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 3</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_09">
-        <property name="geometry">
-         <rect>
-          <x>740</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 4</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_10">
-        <property name="geometry">
-         <rect>
-          <x>810</x>
-          <y>30</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 5</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_11">
-        <property name="geometry">
-         <rect>
-          <x>160</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 1</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_12">
-        <property name="geometry">
-         <rect>
-          <x>230</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 2</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_13">
-        <property name="geometry">
-         <rect>
-          <x>300</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 3</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_14">
-        <property name="geometry">
-         <rect>
-          <x>370</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 4</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_15">
-        <property name="geometry">
-         <rect>
-          <x>440</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 5</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_16">
-        <property name="geometry">
-         <rect>
-          <x>530</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 1</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_17">
-        <property name="geometry">
-         <rect>
-          <x>600</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 2</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_18">
-        <property name="geometry">
-         <rect>
-          <x>670</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 3</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_19">
-        <property name="geometry">
-         <rect>
-          <x>740</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 4</string>
-        </property>
-       </widget>
-       <widget class="Element::Tag" name="tag_20">
-        <property name="geometry">
-         <rect>
-          <x>810</x>
-          <y>80</y>
-          <width>51</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Tag 5</string>
-        </property>
-       </widget>
-       <widget class="Element::Table" name="table">
-        <property name="geometry">
-         <rect>
-          <x>40</x>
-          <y>190</y>
-          <width>851</width>
-          <height>251</height>
-         </rect>
-        </property>
-        <property name="rowCount">
-         <number>4</number>
-        </property>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <column>
-         <property name="text">
-          <string>Date</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Name</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Address</string>
-         </property>
-        </column>
-        <item row="0" column="0">
-         <property name="text">
-          <string>2016-05-03</string>
-         </property>
+       <layout class="QVBoxLayout" name="verticalLayout_11">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <property name="spacing">
+           <number>50</number>
+          </property>
+          <property name="leftMargin">
+           <number>20</number>
+          </property>
+          <property name="topMargin">
+           <number>20</number>
+          </property>
+          <property name="rightMargin">
+           <number>20</number>
+          </property>
+          <property name="bottomMargin">
+           <number>20</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_22">
+            <property name="spacing">
+             <number>50</number>
+            </property>
+            <property name="leftMargin">
+             <number>20</number>
+            </property>
+            <property name="rightMargin">
+             <number>20</number>
+            </property>
+            <item>
+             <widget class="Element::Avatar" name="avatar">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>50</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>avatar</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="horizontalSpacing">
+               <number>40</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>20</number>
+              </property>
+              <item row="0" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_17">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="Element::Tag" name="tag_01" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_02" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_03" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_04" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_05" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_18">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="Element::Tag" name="tag_06" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_07" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_08" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_09" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_10" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_19">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="Element::Tag" name="tag_11" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_12" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_13" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_14" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_15" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_20">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="Element::Tag" name="tag_16" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_17" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_18" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_19" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_20" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>60</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="0" colspan="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_21">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="Element::Tag" name="tag_21" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_22" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_23" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_24" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Element::Tag" name="tag_25" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>80</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color: rgb(170, 170, 170);</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_21">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_19">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="Element::Table" name="table">
+            <property name="rowCount">
+             <number>4</number>
+            </property>
+            <row/>
+            <row/>
+            <row/>
+            <row/>
+            <column>
+             <property name="text">
+              <string>Date</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Address</string>
+             </property>
+            </column>
+            <item row="0" column="0">
+             <property name="text">
+              <string>2016-05-03</string>
+             </property>
+            </item>
+            <item row="0" column="1">
+             <property name="text">
+              <string>Tom</string>
+             </property>
+            </item>
+            <item row="0" column="2">
+             <property name="text">
+              <string>No. 189, Grove St, Los Angeles</string>
+             </property>
+            </item>
+            <item row="1" column="0">
+             <property name="text">
+              <string>2016-05-02</string>
+             </property>
+            </item>
+            <item row="1" column="1">
+             <property name="text">
+              <string>Tom</string>
+             </property>
+            </item>
+            <item row="1" column="2">
+             <property name="text">
+              <string>No. 189, Grove St, Los Angeles</string>
+             </property>
+            </item>
+            <item row="2" column="0">
+             <property name="text">
+              <string>2016-05-04</string>
+             </property>
+            </item>
+            <item row="2" column="1">
+             <property name="text">
+              <string>Tom</string>
+             </property>
+            </item>
+            <item row="2" column="2">
+             <property name="text">
+              <string>No. 189, Grove St, Los Angeles</string>
+             </property>
+            </item>
+            <item row="3" column="0">
+             <property name="text">
+              <string>2016-05-01</string>
+             </property>
+            </item>
+            <item row="3" column="1">
+             <property name="text">
+              <string>Tom</string>
+             </property>
+            </item>
+            <item row="3" column="2">
+             <property name="text">
+              <string>No. 189, Grove St, Los Angeles</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item row="0" column="1">
-         <property name="text">
-          <string>Tom</string>
-         </property>
-        </item>
-        <item row="0" column="2">
-         <property name="text">
-          <string>No. 189, Grove St, Los Angeles</string>
-         </property>
-        </item>
-        <item row="1" column="0">
-         <property name="text">
-          <string>2016-05-02</string>
-         </property>
-        </item>
-        <item row="1" column="1">
-         <property name="text">
-          <string>Tom</string>
-         </property>
-        </item>
-        <item row="1" column="2">
-         <property name="text">
-          <string>No. 189, Grove St, Los Angeles</string>
-         </property>
-        </item>
-        <item row="2" column="0">
-         <property name="text">
-          <string>2016-05-04</string>
-         </property>
-        </item>
-        <item row="2" column="1">
-         <property name="text">
-          <string>Tom</string>
-         </property>
-        </item>
-        <item row="2" column="2">
-         <property name="text">
-          <string>No. 189, Grove St, Los Angeles</string>
-         </property>
-        </item>
-        <item row="3" column="0">
-         <property name="text">
-          <string>2016-05-01</string>
-         </property>
-        </item>
-        <item row="3" column="1">
-         <property name="text">
-          <string>Tom</string>
-         </property>
-        </item>
-        <item row="3" column="2">
-         <property name="text">
-          <string>No. 189, Grove St, Los Angeles</string>
-         </property>
-        </item>
-       </widget>
+       </layout>
       </widget>
       <widget class="QWidget" name="tab_7">
        <attribute name="title">
@@ -3056,11 +3461,6 @@
    <header>avatar.h</header>
   </customwidget>
   <customwidget>
-   <class>Element::Tag</class>
-   <extends>QLabel</extends>
-   <header>tag.h</header>
-  </customwidget>
-  <customwidget>
    <class>Element::Table</class>
    <extends>QTableWidget</extends>
    <header>table.h</header>
@@ -3176,6 +3576,12 @@
    <class>Element::Progress</class>
    <extends>QWidget</extends>
    <header>progress.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Element::Tag</class>
+   <extends>QWidget</extends>
+   <header>tag.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/gallery/main.cpp
+++ b/gallery/main.cpp
@@ -9,6 +9,7 @@ void configurator(Element::Menu* menu, Element::Stack* stack);
 
 int main(int argc, char* argv[])
 {
+    qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
     Element::App app(argc, argv);
 
 #ifdef EXAMPLE


### PR DESCRIPTION
#### 之前Tag关闭动画由于实现原理，存在两个问题
1. 动画会改变控件的宽度策略（ignored）。假如将Tag放在一个layout中，而该layout放入了一个expanding的spacer来实现关闭后的自动对齐的话，在关闭的一瞬间Tag的宽度会瞬间被压缩为0，从而失去动画效果；

2. 之前的动画方法通过Tag的长度收缩来模拟翻转效果（改变geometry属性），这种方法子控件不会跟着收缩，而是子控件内容会被遮挡，在Tag较长时效果不好。

#### 解决方法
将控件改为paintevent绘制，从而可以使用scale属性动画，实现真正的整体收缩来模拟翻转效果，且不用担心动画期间占位问题。

效果演示：
<img width="1278" height="837" alt="GIF" src="https://github.com/user-attachments/assets/c45d66b8-20dc-479d-85ef-c324c12b09ec" />
